### PR TITLE
Have CI ensure there aren't any yarn.lock changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
                   path: ~/repo/packages/abi-gen/test-cli/output
             - store_artifacts:
                   path: ~/repo/packages/contract-wrappers/generated_docs
+            - run: git diff --exit-code yarn.lock
     test-exchange-ganache:
         resource_class: medium+
         docker:


### PR DESCRIPTION
## Description

Add a check to the `build` stage of the CI configuration that will fail if there are any local changes to `yarn.lock` after running `yarn install`.

A "passing" scenario looks like:
<!--- Describe your changes in detail -->
![image](https://user-images.githubusercontent.com/7883777/97034342-c3a74700-1532-11eb-94f1-b6e3e5df953d.png)

A "failing" scenario looks like:

![image](https://user-images.githubusercontent.com/7883777/97035943-108c1d00-1535-11eb-8e8b-71ba292e8d41.png)
