### PR TITLE
adds amendments to the rollout feature flag. Rollout indicative quote…

### DIFF
--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -90,7 +90,10 @@ const DEFAULT_SWAP_QUOTE_REQUEST_OPTS: SwapQuoteRequestOpts = {
 
 const DEFAULT_RFQT_REQUEST_OPTS: Partial<RfqtRequestOpts> = {
     makerEndpointMaxResponseTimeMs: 1000,
-    isPriceAwareRFQEnabled: false,
+    priceAwareRFQFlag: {
+        isFirmPriceAwareEnabled: false,
+        isIndicativePriceAwareEnabled: false,
+    },
 };
 
 export const DEFAULT_INFO_LOGGER: LogFunction = (obj, msg) =>

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -41,6 +41,7 @@ import { ProtocolFeeUtils } from './utils/protocol_fee_utils';
 import { QuoteRequestor } from './utils/quote_requestor';
 import { sortingUtils } from './utils/sorting_utils';
 import { SwapQuoteCalculator } from './utils/swap_quote_calculator';
+import { getPriceAwareRFQRolloutFlags } from './utils/utils';
 import { ERC20BridgeSamplerContract } from './wrappers';
 
 export class SwapQuoter {
@@ -700,7 +701,7 @@ export class SwapQuoter {
 
         if (
             opts.rfqt && // This is an RFQT-enabled API request
-            !opts.rfqt.isPriceAwareRFQEnabled && // If Price-aware RFQ is enabled, firm quotes are requested later on in the process.
+            !getPriceAwareRFQRolloutFlags(opts.rfqt.isPriceAwareRFQEnabled).isFirmPriceAwareEnabled && // If Price-aware RFQ is enabled, firm quotes are requested later on in the process.
             opts.rfqt.intentOnFilling && // The requestor is asking for a firm quote
             opts.rfqt.apiKey &&
             this._isApiKeyWhitelisted(opts.rfqt.apiKey) && // A valid API key was provided

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -701,7 +701,7 @@ export class SwapQuoter {
 
         if (
             opts.rfqt && // This is an RFQT-enabled API request
-            !getPriceAwareRFQRolloutFlags(opts.rfqt.isPriceAwareRFQEnabled).isFirmPriceAwareEnabled && // If Price-aware RFQ is enabled, firm quotes are requested later on in the process.
+            !getPriceAwareRFQRolloutFlags(opts.rfqt.priceAwareRFQFlag).isFirmPriceAwareEnabled && // If Price-aware RFQ is enabled, firm quotes are requested later on in the process.
             opts.rfqt.intentOnFilling && // The requestor is asking for a firm quote
             opts.rfqt.apiKey &&
             this._isApiKeyWhitelisted(opts.rfqt.apiKey) && // A valid API key was provided

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -234,6 +234,11 @@ export type SwapQuoteOrdersBreakdown = Partial<
     }
 >;
 
+export interface PriceAwareRFQFlags {
+    isIndicativePriceAwareEnabled: boolean;
+    isFirmPriceAwareEnabled: boolean;
+}
+
 /**
  * nativeExclusivelyRFQT: if set to `true`, Swap quote will exclude Open Orderbook liquidity.
  *                        If set to `true` and `ERC20BridgeSource.Native` is part of the `excludedSources`
@@ -256,7 +261,7 @@ export interface RfqtRequestOpts {
      * the feature flag.  When that time comes, follow this PR to "undo" the feature flag:
      * https://github.com/0xProject/0x-monorepo/pull/2735
      */
-    isPriceAwareRFQEnabled?: boolean;
+    priceAwareRFQFlag?: PriceAwareRFQFlags;
 }
 
 /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -216,7 +216,7 @@ export class MarketOperationUtils {
         );
 
         const isPriceAwareRfqEnabled =
-            _opts.rfqt && getPriceAwareRFQRolloutFlags(_opts.rfqt.isPriceAwareRFQEnabled).isIndicativePriceAwareEnabled;
+            _opts.rfqt && getPriceAwareRFQRolloutFlags(_opts.rfqt.priceAwareRFQFlag).isIndicativePriceAwareEnabled;
         const rfqtPromise =
             !isPriceAwareRfqEnabled && quoteSourceFilters.isAllowed(ERC20BridgeSource.Native)
                 ? getRfqtIndicativeQuotesAsync(
@@ -365,7 +365,7 @@ export class MarketOperationUtils {
             ),
         );
         const isPriceAwareRfqEnabled =
-            _opts.rfqt && getPriceAwareRFQRolloutFlags(_opts.rfqt.isPriceAwareRFQEnabled).isIndicativePriceAwareEnabled;
+            _opts.rfqt && getPriceAwareRFQRolloutFlags(_opts.rfqt.priceAwareRFQFlag).isIndicativePriceAwareEnabled;
         const rfqtPromise =
             !isPriceAwareRfqEnabled && quoteSourceFilters.isAllowed(ERC20BridgeSource.Native)
                 ? getRfqtIndicativeQuotesAsync(
@@ -705,7 +705,7 @@ export class MarketOperationUtils {
             }
 
             const { isFirmPriceAwareEnabled, isIndicativePriceAwareEnabled } = getPriceAwareRFQRolloutFlags(
-                rfqt.isPriceAwareRFQEnabled,
+                rfqt.priceAwareRFQFlag,
             );
 
             if (rfqt.isIndicative && isIndicativePriceAwareEnabled) {

--- a/packages/asset-swapper/src/utils/utils.ts
+++ b/packages/asset-swapper/src/utils/utils.ts
@@ -4,6 +4,7 @@ import { BigNumber, NULL_BYTES } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 
 import { constants } from '../constants';
+import { PriceAwareRFQFlags } from '../types';
 
 // tslint:disable: no-unnecessary-type-assertion completed-docs
 
@@ -11,28 +12,17 @@ import { constants } from '../constants';
  * Returns 2 flags (one for firm quotes and another for indicative quotes) that serve as rollout flags for the price-aware RFQ feature.
  * By default, indicative quotes should *always* go through the new price-aware flow. This means that all indicative RFQ requests made to
  * market makers will contain the new price-aware `suggestedPrice` field.
- * The `isPriceAwareRFQEnabled` feature flag that is passed in by the 0x API will then control whether firm quotes go through price-aware RFQ.
- *
- * NOTE: You may notice how `isIndicativePriceAwareEnabled` is always hard-coded to `true` and is redundant. The reason we keep this parameter here is
- * to separate the rollout logic from the already-complicated business logic in the Asset Swapper. If there is a need to pause the rollout and shutdown
- * indicative quotes, it's much easier to do so by changing the output of this function instead of changing multiple files in the asset swapper logic.
+ * The `isPriceAwareRFQEnabled` feature object that is passed in by the 0x API will then control whether firm quotes go through price-aware RFQ.
  *
  * @param isPriceAwareRFQEnabled the feature flag that is passed in by the 0x API.
  */
-export function getPriceAwareRFQRolloutFlags(
-    isPriceAwareRFQEnabled?: boolean,
-): { isIndicativePriceAwareEnabled: boolean; isFirmPriceAwareEnabled: boolean } {
-    if (isPriceAwareRFQEnabled) {
-        return {
-            isIndicativePriceAwareEnabled: true,
-            isFirmPriceAwareEnabled: true,
-        };
-    } else {
-        return {
-            isIndicativePriceAwareEnabled: true,
-            isFirmPriceAwareEnabled: false,
-        };
-    }
+export function getPriceAwareRFQRolloutFlags(priceAwareRFQFlags?: PriceAwareRFQFlags): PriceAwareRFQFlags {
+    return priceAwareRFQFlags !== undefined
+        ? priceAwareRFQFlags
+        : {
+              isFirmPriceAwareEnabled: false,
+              isIndicativePriceAwareEnabled: false,
+          };
 }
 
 export function isSupportedAssetDataInOrders(orders: SignedOrder[]): boolean {

--- a/packages/asset-swapper/src/utils/utils.ts
+++ b/packages/asset-swapper/src/utils/utils.ts
@@ -7,6 +7,34 @@ import { constants } from '../constants';
 
 // tslint:disable: no-unnecessary-type-assertion completed-docs
 
+/**
+ * Returns 2 flags (one for firm quotes and another for indicative quotes) that serve as rollout flags for the price-aware RFQ feature.
+ * By default, indicative quotes should *always* go through the new price-aware flow. This means that all indicative RFQ requests made to
+ * market makers will contain the new price-aware `suggestedPrice` field.
+ * The `isPriceAwareRFQEnabled` feature flag that is passed in by the 0x API will then control whether firm quotes go through price-aware RFQ.
+ *
+ * NOTE: You may notice how `isIndicativePriceAwareEnabled` is always hard-coded to `true` and is redundant. The reason we keep this parameter here is
+ * to separate the rollout logic from the already-complicated business logic in the Asset Swapper. If there is a need to pause the rollout and shutdown
+ * indicative quotes, it's much easier to do so by changing the output of this function instead of changing multiple files in the asset swapper logic.
+ *
+ * @param isPriceAwareRFQEnabled the feature flag that is passed in by the 0x API.
+ */
+export function getPriceAwareRFQRolloutFlags(
+    isPriceAwareRFQEnabled?: boolean,
+): { isIndicativePriceAwareEnabled: boolean; isFirmPriceAwareEnabled: boolean } {
+    if (isPriceAwareRFQEnabled) {
+        return {
+            isIndicativePriceAwareEnabled: true,
+            isFirmPriceAwareEnabled: true,
+        };
+    } else {
+        return {
+            isIndicativePriceAwareEnabled: true,
+            isFirmPriceAwareEnabled: false,
+        };
+    }
+}
+
 export function isSupportedAssetDataInOrders(orders: SignedOrder[]): boolean {
     const firstOrderMakerAssetData = !!orders[0]
         ? assetDataUtils.decodeAssetDataOrThrow(orders[0].makerAssetData)

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -17,6 +17,7 @@ import * as _ from 'lodash';
 import * as TypeMoq from 'typemoq';
 
 import { MarketOperation, QuoteRequestor, RfqtRequestOpts, SignedOrderWithFillableAmounts } from '../src';
+import { PriceAwareRFQFlags } from '../src/types';
 import { getRfqtIndicativeQuotesAsync, MarketOperationUtils } from '../src/utils/market_operation_utils/';
 import { BalancerPoolsCache } from '../src/utils/market_operation_utils/balancer_utils';
 import {
@@ -66,6 +67,10 @@ const DEFAULT_EXCLUDED = [
 const BUY_SOURCES = BUY_SOURCE_FILTER.sources;
 const SELL_SOURCES = SELL_SOURCE_FILTER.sources;
 const TOKEN_ADJACENCY_GRAPH: TokenAdjacencyGraph = {};
+const PRICE_AWARE_RFQ_ENABLED: PriceAwareRFQFlags = {
+    isFirmPriceAwareEnabled: true,
+    isIndicativePriceAwareEnabled: true,
+};
 
 // tslint:disable: custom-no-magic-numbers promise-function-async
 describe('MarketOperationUtils tests', () => {
@@ -891,7 +896,7 @@ describe('MarketOperationUtils tests', () => {
                             apiKey: 'foo',
                             takerAddress: randomAddress(),
                             intentOnFilling: true,
-                            isPriceAwareRFQEnabled: true,
+                            priceAwareRFQFlag: PRICE_AWARE_RFQ_ENABLED,
                             quoteRequestor: {
                                 requestRfqtFirmQuotesAsync: mockedQuoteRequestor.object.requestRfqtFirmQuotesAsync,
                             } as any,
@@ -931,7 +936,7 @@ describe('MarketOperationUtils tests', () => {
                         apiKey: 'foo',
                         takerAddress: randomAddress(),
                         intentOnFilling: true,
-                        isPriceAwareRFQEnabled: true,
+                        priceAwareRFQFlag: PRICE_AWARE_RFQ_ENABLED,
                         quoteRequestor: {
                             requestRfqtFirmQuotesAsync: requestor.object.requestRfqtFirmQuotesAsync,
                         } as any,
@@ -974,7 +979,7 @@ describe('MarketOperationUtils tests', () => {
                         rfqt: {
                             isIndicative: true,
                             apiKey: 'foo',
-                            isPriceAwareRFQEnabled: true,
+                            priceAwareRFQFlag: PRICE_AWARE_RFQ_ENABLED,
                             takerAddress: randomAddress(),
                             intentOnFilling: true,
                             quoteRequestor: {
@@ -1033,7 +1038,7 @@ describe('MarketOperationUtils tests', () => {
                             apiKey: 'foo',
                             takerAddress: randomAddress(),
                             intentOnFilling: true,
-                            isPriceAwareRFQEnabled: true,
+                            priceAwareRFQFlag: PRICE_AWARE_RFQ_ENABLED,
                             quoteRequestor: {
                                 requestRfqtFirmQuotesAsync: requestor.object.requestRfqtFirmQuotesAsync,
                             } as any,
@@ -1089,7 +1094,7 @@ describe('MarketOperationUtils tests', () => {
                             isIndicative: false,
                             apiKey: 'foo',
                             takerAddress: randomAddress(),
-                            isPriceAwareRFQEnabled: true,
+                            priceAwareRFQFlag: PRICE_AWARE_RFQ_ENABLED,
                             intentOnFilling: true,
                             quoteRequestor: {
                                 requestRfqtFirmQuotesAsync: requestor.object.requestRfqtFirmQuotesAsync,


### PR DESCRIPTION
Adds some new logic to the `isPriceAwareRFQEnabled` feature flag.

By default, indicative quotes should go through the new price-aware route (regardless of the value in `isPriceAwareRFQEnabled`). Firm quotes will go through the new price-aware route only when enabled by `isPriceAwareRFQEnabled` flag.