### PR TITLE
Convert MetaTransactionsFeature to use the new LibSignature

### DIFF
--- a/contracts/integrations/test/exchange-proxy/mtx_test.ts
+++ b/contracts/integrations/test/exchange-proxy/mtx_test.ts
@@ -6,6 +6,7 @@ import {
     artifacts as exchangeProxyArtifacts,
     IZeroExContract,
     LogMetadataTransformerContract,
+    Signature,
     signCallData,
 } from '@0x/contracts-zero-ex';
 import { migrateOnceAsync } from '@0x/migrations';
@@ -24,6 +25,15 @@ import { BigNumber, hexUtils, ZeroExRevertErrors } from '@0x/utils';
 import * as ethjs from 'ethereumjs-util';
 
 const { MAX_UINT256, NULL_ADDRESS, NULL_BYTES, NULL_BYTES32, ZERO_AMOUNT } = constants;
+
+function sigstruct(signature: string): Signature {
+    return {
+        v: parseInt(hexUtils.slice(signature, 0, 1), 16),
+        signatureType: parseInt(hexUtils.slice(signature, 65, 66), 16),
+        r: hexUtils.slice(signature, 1, 33),
+        s: hexUtils.slice(signature, 33, 65),
+    };
+}
 
 blockchainTests.resets('exchange proxy - meta-transactions', env => {
     const quoteSignerKey = hexUtils.random();
@@ -240,7 +250,7 @@ blockchainTests.resets('exchange proxy - meta-transactions', env => {
         const mtx = await createMetaTransactionAsync(signedSwapData, _protocolFee, 0);
         const relayerEthBalanceBefore = await env.web3Wrapper.getBalanceInWeiAsync(relayer);
         const receipt = await zeroEx
-            .executeMetaTransaction(mtx, mtx.signature)
+            .executeMetaTransaction(mtx, sigstruct(mtx.signature))
             .awaitTransactionSuccessAsync({ from: relayer, value: mtx.value, gasPrice: GAS_PRICE });
         const relayerEthRefund = relayerEthBalanceBefore
             .minus(await env.web3Wrapper.getBalanceInWeiAsync(relayer))
@@ -276,7 +286,7 @@ blockchainTests.resets('exchange proxy - meta-transactions', env => {
         const mtx = await createMetaTransactionAsync(signedSwapData, _protocolFee);
         const relayerEthBalanceBefore = await env.web3Wrapper.getBalanceInWeiAsync(relayer);
         const receipt = await zeroEx
-            .executeMetaTransaction(mtx, mtx.signature)
+            .executeMetaTransaction(mtx, sigstruct(mtx.signature))
             .awaitTransactionSuccessAsync({ from: relayer, value: mtx.value, gasPrice: GAS_PRICE });
         const relayerEthRefund = relayerEthBalanceBefore
             .minus(await env.web3Wrapper.getBalanceInWeiAsync(relayer))
@@ -311,7 +321,7 @@ blockchainTests.resets('exchange proxy - meta-transactions', env => {
         const mtx = await createMetaTransactionAsync(signedSwapData, _protocolFee);
         const relayerEthBalanceBefore = await env.web3Wrapper.getBalanceInWeiAsync(relayer);
         const receipt = await zeroEx
-            .executeMetaTransaction(mtx, mtx.signature)
+            .executeMetaTransaction(mtx, sigstruct(mtx.signature))
             .awaitTransactionSuccessAsync({ from: relayer, value: mtx.value, gasPrice: GAS_PRICE });
         const relayerEthRefund = relayerEthBalanceBefore
             .minus(await env.web3Wrapper.getBalanceInWeiAsync(relayer))
@@ -348,7 +358,7 @@ blockchainTests.resets('exchange proxy - meta-transactions', env => {
         const mtx = await createMetaTransactionAsync(signedSwapData, _protocolFee, 0);
         const relayerEthBalanceBefore = await env.web3Wrapper.getBalanceInWeiAsync(relayer);
         const receipt = await zeroEx
-            .executeMetaTransaction(mtx, mtx.signature)
+            .executeMetaTransaction(mtx, sigstruct(mtx.signature))
             .awaitTransactionSuccessAsync({ from: relayer, value: mtx.value, gasPrice: GAS_PRICE });
         const relayerEthRefund = relayerEthBalanceBefore
             .minus(await env.web3Wrapper.getBalanceInWeiAsync(relayer))
@@ -385,7 +395,7 @@ blockchainTests.resets('exchange proxy - meta-transactions', env => {
         const relayerEthBalanceBefore = await env.web3Wrapper.getBalanceInWeiAsync(relayer);
         await zeroEx.setQuoteSigner(NULL_ADDRESS).awaitTransactionSuccessAsync({ from: owner });
         const receipt = await zeroEx
-            .executeMetaTransaction(mtx, mtx.signature)
+            .executeMetaTransaction(mtx, sigstruct(mtx.signature))
             .awaitTransactionSuccessAsync({ from: relayer, value: mtx.value, gasPrice: GAS_PRICE });
         const relayerEthRefund = relayerEthBalanceBefore
             .minus(await env.web3Wrapper.getBalanceInWeiAsync(relayer))
@@ -419,7 +429,7 @@ blockchainTests.resets('exchange proxy - meta-transactions', env => {
         const _protocolFee = protocolFee.times(GAS_PRICE).times(swap.orders.length + 1); // Pay a little more fee than needed.
         const mtx = await createMetaTransactionAsync(callData, _protocolFee, 0);
         const tx = zeroEx
-            .executeMetaTransaction(mtx, mtx.signature)
+            .executeMetaTransaction(mtx, sigstruct(mtx.signature))
             .awaitTransactionSuccessAsync({ from: relayer, value: mtx.value, gasPrice: GAS_PRICE });
         return expect(tx).to.revertWith(new ZeroExRevertErrors.MetaTransactions.MetaTransactionCallFailedError());
     });

--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -21,6 +21,10 @@
             {
                 "note": "Add a gas limit to first `LibTokenSpender` and `UniswapFeature` transfer",
                 "pr": 38
+            },
+            {
+                "note": "Convert metatransactions to use `LibSignature`",
+                "pr": 31
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/features/IMetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/IMetaTransactionsFeature.sol
@@ -20,10 +20,27 @@ pragma solidity ^0.6.5;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-erc20/contracts/src/v06/IERC20TokenV06.sol";
-
+import "./libs/LibSignature.sol";
 
 /// @dev Meta-transactions feature.
 interface IMetaTransactionsFeature {
+    /// @dev Describes the state of a meta transaction.
+    struct ExecuteState {
+        // Sender of the meta-transaction.
+        address sender;
+        // Hash of the meta-transaction data.
+        bytes32 hash;
+        // The meta-transaction data.
+        MetaTransactionData mtx;
+        // The meta-transaction signature (by `mtx.signer`).
+        LibSignature.Signature signature;
+        // The selector of the function being called.
+        bytes4 selector;
+        // The ETH balance of this contract before performing the call.
+        uint256 selfBalance;
+        // The block number at which the meta-transaction was executed.
+        uint256 executedBlockNumber;
+    }
 
     /// @dev Describes an exchange proxy meta transaction.
     struct MetaTransactionData {
@@ -88,15 +105,10 @@ interface IMetaTransactionsFeature {
 
     /// @dev Execute a meta-transaction via `sender`. Privileged variant.
     ///      Only callable from within.
-    /// @param sender Who is executing the meta-transaction..
-    /// @param mtx The meta-transaction.
-    /// @param signature The signature by `mtx.signer`.
+    /// @param state The `ExecuteState` for this metatransaction, with `sender`,
+    ///              `hash`, `mtx`, and `signature` fields filled.
     /// @return returnResult The ABI-encoded result of the underlying call.
-    function _executeMetaTransaction(
-        address sender,
-        MetaTransactionData calldata mtx,
-        bytes calldata signature
-    )
+    function _executeMetaTransaction(ExecuteState memory state)
         external
         payable
         returns (bytes memory returnResult);

--- a/contracts/zero-ex/contracts/src/features/IMetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/IMetaTransactionsFeature.sol
@@ -24,24 +24,6 @@ import "./libs/LibSignature.sol";
 
 /// @dev Meta-transactions feature.
 interface IMetaTransactionsFeature {
-    /// @dev Describes the state of a meta transaction.
-    struct ExecuteState {
-        // Sender of the meta-transaction.
-        address sender;
-        // Hash of the meta-transaction data.
-        bytes32 hash;
-        // The meta-transaction data.
-        MetaTransactionData mtx;
-        // The meta-transaction signature (by `mtx.signer`).
-        LibSignature.Signature signature;
-        // The selector of the function being called.
-        bytes4 selector;
-        // The ETH balance of this contract before performing the call.
-        uint256 selfBalance;
-        // The block number at which the meta-transaction was executed.
-        uint256 executedBlockNumber;
-    }
-
     /// @dev Describes an exchange proxy meta transaction.
     struct MetaTransactionData {
         // Signer of meta-transaction. On whose behalf to execute the MTX.
@@ -85,7 +67,7 @@ interface IMetaTransactionsFeature {
     /// @return returnResult The ABI-encoded result of the underlying call.
     function executeMetaTransaction(
         MetaTransactionData calldata mtx,
-        bytes calldata signature
+        LibSignature.Signature calldata signature
     )
         external
         payable
@@ -97,7 +79,7 @@ interface IMetaTransactionsFeature {
     /// @return returnResults The ABI-encoded results of the underlying calls.
     function batchExecuteMetaTransactions(
         MetaTransactionData[] calldata mtxs,
-        bytes[] calldata signatures
+        LibSignature.Signature[] calldata signatures
     )
         external
         payable
@@ -105,10 +87,15 @@ interface IMetaTransactionsFeature {
 
     /// @dev Execute a meta-transaction via `sender`. Privileged variant.
     ///      Only callable from within.
-    /// @param state The `ExecuteState` for this metatransaction, with `sender`,
-    ///              `hash`, `mtx`, and `signature` fields filled.
+    /// @param sender Who is executing the meta-transaction.
+    /// @param mtx The meta-transaction.
+    /// @param signature The signature by `mtx.signer`.
     /// @return returnResult The ABI-encoded result of the underlying call.
-    function _executeMetaTransaction(ExecuteState memory state)
+    function _executeMetaTransaction(
+        address sender,
+        MetaTransactionData memory mtx,
+        LibSignature.Signature memory signature
+    )
         external
         payable
         returns (bytes memory returnResult);

--- a/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
@@ -32,6 +32,7 @@ import "../storage/LibMetaTransactionsStorage.sol";
 import "./libs/LibSignedCallData.sol";
 import "./IMetaTransactionsFeature.sol";
 import "./ITransformERC20Feature.sol";
+import "./libs/LibSignature.sol";
 import "./ISignatureValidatorFeature.sol";
 import "./IFeature.sol";
 
@@ -348,17 +349,34 @@ contract MetaTransactionsFeature is
                     state.mtx.value
                 ).rrevert();
         }
-        // Must be signed by signer.
-        try
-            ISignatureValidatorFeature(address(this))
-                .validateHashSignature(state.hash, state.mtx.signer, state.signature)
-        {}
-        catch (bytes memory err) {
+
+        if (state.signature.length != 66) {
+            LibSignatureRichErrors.SignatureValidationError(
+                LibSignatureRichErrors.SignatureValidationErrorCodes.INVALID_LENGTH,
+                state.hash,
+                state.mtx.signer,
+                state.signature
+            ).rrevert();
+        }
+
+        LibSignature.Signature memory sig = LibSignature.Signature({
+            signatureType: LibSignature.SignatureType(uint8(state.signature[65])),
+            v: uint8(state.signature[0]),
+            r: state.signature.readBytes32(1),
+            s: state.signature.readBytes32(33)
+        });
+
+        if (LibSignature.getSignerOfHash(state.hash, sig) != state.mtx.signer) {
             LibMetaTransactionsRichErrors
                 .MetaTransactionInvalidSignatureError(
                     state.hash,
                     state.signature,
-                    err
+                    LibSignatureRichErrors.SignatureValidationError(
+                        LibSignatureRichErrors.SignatureValidationErrorCodes.WRONG_SIGNER,
+                        state.hash,
+                        state.mtx.signer,
+                        state.signature
+                    )
                 ).rrevert();
         }
         // Transaction must not have been already executed.

--- a/contracts/zero-ex/contracts/test/TestMetaTransactionsTransformERC20Feature.sol
+++ b/contracts/zero-ex/contracts/test/TestMetaTransactionsTransformERC20Feature.sol
@@ -52,6 +52,8 @@ contract TestMetaTransactionsTransformERC20Feature is
         }
 
         if (msg.value == 777) {
+            LibSignature.Signature memory signature;
+
             // Try to reenter `executeMetaTransaction()`
             IMetaTransactionsFeature(address(this)).executeMetaTransaction(
                 IMetaTransactionsFeature.MetaTransactionData({
@@ -66,7 +68,7 @@ contract TestMetaTransactionsTransformERC20Feature is
                     feeToken: IERC20TokenV06(0),
                     feeAmount: 0
                 }),
-                ""
+                signature
             );
         }
 
@@ -74,7 +76,7 @@ contract TestMetaTransactionsTransformERC20Feature is
             // Try to reenter `batchExecuteMetaTransactions()`
             IMetaTransactionsFeature.MetaTransactionData[] memory mtxs =
                 new IMetaTransactionsFeature.MetaTransactionData[](1);
-            bytes[] memory signatures = new bytes[](1);
+            LibSignature.Signature[] memory signatures = new LibSignature.Signature[](1);
             mtxs[0] = IMetaTransactionsFeature.MetaTransactionData({
                 signer: address(0),
                 sender: address(0),
@@ -87,7 +89,6 @@ contract TestMetaTransactionsTransformERC20Feature is
                 feeToken: IERC20TokenV06(0),
                 feeAmount: 0
             });
-            signatures[0] = "";
             IMetaTransactionsFeature(address(this)).batchExecuteMetaTransactions(
                 mtxs,
                 signatures

--- a/contracts/zero-ex/test/features/meta_transactions_test.ts
+++ b/contracts/zero-ex/test/features/meta_transactions_test.ts
@@ -461,15 +461,11 @@ blockchainTests.resets('MetaTransactions feature', env => {
             };
             const tx = feature.executeMetaTransaction(mtx, signature).awaitTransactionSuccessAsync(callOpts);
             return expect(tx).to.revertWith(
-                new ZeroExRevertErrors.MetaTransactions.MetaTransactionInvalidSignatureError(
+                new ZeroExRevertErrors.SignatureValidator.SignatureValidationError(
+                    ZeroExRevertErrors.SignatureValidator.SignatureValidationErrorCodes.WrongSigner,
                     mtxHash,
-                    signature,
-                    new ZeroExRevertErrors.SignatureValidator.SignatureValidationError(
-                        ZeroExRevertErrors.SignatureValidator.SignatureValidationErrorCodes.WrongSigner,
-                        mtxHash,
-                        signers[0],
-                        signature,
-                    ).encode(),
+                    signers[0],
+                    "0x",
                 ),
             );
         });

--- a/contracts/zero-ex/test/features/meta_transactions_test.ts
+++ b/contracts/zero-ex/test/features/meta_transactions_test.ts
@@ -465,7 +465,7 @@ blockchainTests.resets('MetaTransactions feature', env => {
                     ZeroExRevertErrors.SignatureValidator.SignatureValidationErrorCodes.WrongSigner,
                     mtxHash,
                     signers[0],
-                    "0x",
+                    '0x',
                 ),
             );
         });

--- a/contracts/zero-ex/test/features/meta_transactions_test.ts
+++ b/contracts/zero-ex/test/features/meta_transactions_test.ts
@@ -24,6 +24,13 @@ import {
 
 const { NULL_ADDRESS, NULL_BYTES, ZERO_AMOUNT } = constants;
 
+interface Signature {
+    signatureType: number;
+    v: number;
+    r: string;
+    s: string;
+}
+
 blockchainTests.resets('MetaTransactions feature', env => {
     let owner: string;
     let sender: string;
@@ -71,6 +78,15 @@ blockchainTests.resets('MetaTransactions feature', env => {
         );
     });
 
+    function sigstruct(signature: string): Signature {
+        return {
+            v: parseInt(hexUtils.slice(signature, 0, 1), 16),
+            signatureType: parseInt(hexUtils.slice(signature, 65, 66), 16),
+            r: hexUtils.slice(signature, 1, 33),
+            s: hexUtils.slice(signature, 33, 65),
+        };
+    }
+
     function getRandomMetaTransaction(
         fields: Partial<ExchangeProxyMetaTransaction> = {},
     ): ExchangeProxyMetaTransaction {
@@ -93,11 +109,13 @@ blockchainTests.resets('MetaTransactions feature', env => {
         };
     }
 
-    async function signMetaTransactionAsync(mtx: ExchangeProxyMetaTransaction, signer?: string): Promise<string> {
-        return signatureUtils.ecSignHashAsync(
-            env.provider,
-            getExchangeProxyMetaTransactionHash(mtx),
-            signer || mtx.signer,
+    async function signMetaTransactionAsync(mtx: ExchangeProxyMetaTransaction, signer?: string): Promise<Signature> {
+        return sigstruct(
+            await signatureUtils.ecSignHashAsync(
+                env.provider,
+                getExchangeProxyMetaTransactionHash(mtx),
+                signer || mtx.signer,
+            ),
         );
     }
 

--- a/contracts/zero-ex/test/features/meta_transactions_test.ts
+++ b/contracts/zero-ex/test/features/meta_transactions_test.ts
@@ -7,7 +7,8 @@ import {
     verifyEventsFromLogs,
 } from '@0x/contracts-test-utils';
 import { getExchangeProxyMetaTransactionHash, signatureUtils } from '@0x/order-utils';
-import { ExchangeProxyMetaTransaction } from '@0x/types';
+import { ExchangeProxyMetaTransaction, SignatureType } from '@0x/types';
+import { Signature } from '../../src/signature_utils';
 import { BigNumber, hexUtils, StringRevertError, ZeroExRevertErrors } from '@0x/utils';
 import * as _ from 'lodash';
 
@@ -23,13 +24,6 @@ import {
 } from '../wrappers';
 
 const { NULL_ADDRESS, NULL_BYTES, ZERO_AMOUNT } = constants;
-
-interface Signature {
-    signatureType: number;
-    v: number;
-    r: string;
-    s: string;
-}
 
 blockchainTests.resets('MetaTransactions feature', env => {
     let owner: string;

--- a/contracts/zero-ex/test/features/meta_transactions_test.ts
+++ b/contracts/zero-ex/test/features/meta_transactions_test.ts
@@ -7,11 +7,11 @@ import {
     verifyEventsFromLogs,
 } from '@0x/contracts-test-utils';
 import { getExchangeProxyMetaTransactionHash, signatureUtils } from '@0x/order-utils';
-import { ExchangeProxyMetaTransaction, SignatureType } from '@0x/types';
-import { Signature } from '../../src/signature_utils';
+import { ExchangeProxyMetaTransaction } from '@0x/types';
 import { BigNumber, hexUtils, StringRevertError, ZeroExRevertErrors } from '@0x/utils';
 import * as _ from 'lodash';
 
+import { Signature } from '../../src/signature_utils';
 import { generateCallDataSignature, signCallData } from '../../src/signed_call_data';
 import { IZeroExContract, MetaTransactionsFeatureContract } from '../../src/wrappers';
 import { artifacts } from '../artifacts';

--- a/contracts/zero-ex/test/full_migration_test.ts
+++ b/contracts/zero-ex/test/full_migration_test.ts
@@ -95,8 +95,7 @@ blockchainTests.resets('Full migration', env => {
             fns: [
                 'executeMetaTransaction',
                 'batchExecuteMetaTransactions',
-                // TODO: Reenable this. Possibly broken due to nested structs?
-                // '_executeMetaTransaction',
+                '_executeMetaTransaction',
                 'getMetaTransactionExecutedBlock',
                 'getMetaTransactionHashExecutedBlock',
                 'getMetaTransactionHash',

--- a/contracts/zero-ex/test/full_migration_test.ts
+++ b/contracts/zero-ex/test/full_migration_test.ts
@@ -95,7 +95,8 @@ blockchainTests.resets('Full migration', env => {
             fns: [
                 'executeMetaTransaction',
                 'batchExecuteMetaTransactions',
-                '_executeMetaTransaction',
+                // TODO: Reenable this. Possibly broken due to nested structs?
+                // '_executeMetaTransaction',
                 'getMetaTransactionExecutedBlock',
                 'getMetaTransactionHashExecutedBlock',
                 'getMetaTransactionHash',


### PR DESCRIPTION
## Description

Convert `MetaTransactionsFeature` to use the new `LibSignature`

## Testing instructions

`yarn build && yarn test` from `contracts/zero-ex`

## Types of changes

* non-breaking change to use `LibSignature` instead of the signature validation feature

## Checklist:

-   [X] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.
-   [X] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.