### PR TITLE
feat: [asset-swapper] support selling entire balance

### DIFF
--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -75,6 +75,7 @@ const DEFAULT_EXCHANGE_PROXY_EXTENSION_CONTRACT_OPTS: ExchangeProxyContractOpts 
     },
     refundReceiver: NULL_ADDRESS,
     isMetaTransaction: false,
+    shouldSellEntireBalance: false,
 };
 
 const DEFAULT_FORWARDER_SWAP_QUOTE_EXECUTE_OPTS: SwapQuoteExecutionOpts = DEFAULT_FORWARDER_SWAP_QUOTE_GET_OPTS;

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -90,7 +90,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
             ...opts.extensionContractOpts,
         };
         // tslint:disable-next-line:no-object-literal-type-assertion
-        const { refundReceiver, affiliateFee, isFromETH, isToETH } = optsWithDefaults;
+        const { refundReceiver, affiliateFee, isFromETH, isToETH, shouldSellEntireBalance } = optsWithDefaults;
 
         const sellToken = getTokenFromAssetData(quote.takerAssetData);
         const buyToken = getTokenFromAssetData(quote.makerAssetData);
@@ -139,7 +139,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                 deploymentNonce: this.transformerNonces.wethTransformer,
                 data: encodeWethTransformerData({
                     token: ETH_TOKEN_ADDRESS,
-                    amount: sellAmount,
+                    amount: shouldSellEntireBalance ? MAX_UINT256 : sellAmount,
                 }),
             });
         }
@@ -155,7 +155,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                     buyToken: intermediateToken,
                     side: FillQuoteTransformerSide.Sell,
                     refundReceiver: refundReceiver || NULL_ADDRESS,
-                    fillAmount: firstHopOrder.takerAssetAmount,
+                    fillAmount: shouldSellEntireBalance ? MAX_UINT256 : firstHopOrder.takerAssetAmount,
                     maxOrderFillAmounts: [],
                     rfqtTakerAddress: NULL_ADDRESS,
                     orders: [firstHopOrder],
@@ -177,6 +177,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                 }),
             });
         } else {
+            const fillAmount = isBuyQuote(quote) ? quote.makerAssetFillAmount : quote.takerAssetFillAmount;
             transforms.push({
                 deploymentNonce: this.transformerNonces.fillQuoteTransformer,
                 data: encodeFillQuoteTransformerData({
@@ -184,7 +185,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                     buyToken,
                     refundReceiver: refundReceiver || NULL_ADDRESS,
                     side: isBuyQuote(quote) ? FillQuoteTransformerSide.Buy : FillQuoteTransformerSide.Sell,
-                    fillAmount: isBuyQuote(quote) ? quote.makerAssetFillAmount : quote.takerAssetFillAmount,
+                    fillAmount: shouldSellEntireBalance ? MAX_UINT256 : fillAmount,
                     maxOrderFillAmounts: [],
                     rfqtTakerAddress: NULL_ADDRESS,
                     orders: quote.orders,
@@ -238,7 +239,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
             .transformERC20(
                 isFromETH ? ETH_TOKEN_ADDRESS : sellToken,
                 isToETH ? ETH_TOKEN_ADDRESS : buyToken,
-                sellAmount,
+                shouldSellEntireBalance ? MAX_UINT256 : sellAmount,
                 minBuyAmount,
                 transforms,
             )
@@ -289,6 +290,10 @@ function isDirectSwapCompatible(
     }
     const fill = order.fills[0];
     if (!directSources.includes(fill.source)) {
+        return false;
+    }
+    // VIP does not support selling the entire balance
+    if (opts.shouldSellEntireBalance) {
         return false;
     }
     return true;

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -156,6 +156,9 @@ export enum ExchangeProxyRefundReceiver {
  *        `address(0)`: Stay in flash wallet.
  *        `address(1)`: Send to the taker.
  *        `address(2)`: Send to the sender (caller of `transformERC20()`).
+ * @param shouldSellEntireBalance Whether the entire balance of the caller should be sold. Used
+ *        for contracts where the balance at transaction time is different to the quote amount.
+ *        This foregos certain VIP routes which do not support this feature.
  */
 export interface ExchangeProxyContractOpts {
     isFromETH: boolean;
@@ -163,6 +166,7 @@ export interface ExchangeProxyContractOpts {
     affiliateFee: AffiliateFee;
     refundReceiver: string | ExchangeProxyRefundReceiver;
     isMetaTransaction: boolean;
+    shouldSellEntireBalance: boolean;
 }
 
 export interface GetExtensionContractTypeOpts {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Allow the caller to specify `shouldSellEntireBalance` to make use of EP `-1`, indicating the amount to be transferred and sold is the entire max balance/allowance of the caller.

Needed for scenarios where the amount can be undeterministic, such as in the middle of an CFL operation.

[Sim - Enabled shouldSellEntireBalance](https://metabase.spaceship.0x.org/dashboard/139?run_id=dev-sell-all-enabled&adjusted_amount_bought_win_tolerance__bps_=0.5)

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
