### PR TITLE
TransformERC20: Fix selling entire ETH balance

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -33,6 +33,10 @@
             {
                 "note": "Require RFQ orders to specify a transaction origin, and allow approved alternative addresses",
                 "pr": 47
+            },
+            {
+                "note": "Do not try to pull all tokens if selling all ETH in `TransformERC20Feature`",
+                "pr": 46
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/features/TransformERC20Feature.sol
+++ b/contracts/zero-ex/contracts/src/features/TransformERC20Feature.sol
@@ -214,13 +214,19 @@ contract TransformERC20Feature is
         private
         returns (uint256 outputTokenAmount)
     {
-        // If the input token amount is -1, transform the taker's entire
-        // spendable balance.
+        // If the input token amount is -1 and we are not selling ETH,
+        // transform the taker's entire spendable balance.
         if (args.inputTokenAmount == uint256(-1)) {
-            args.inputTokenAmount = _getSpendableERC20BalanceOf(
-                args.inputToken,
-                args.taker
-            );
+            if (LibERC20Transformer.isTokenETH(args.inputToken)) {
+                // We can't pull more ETH from the taker, so we just set the
+                // input token amount to the value attached to the call.
+                args.inputTokenAmount = msg.value;
+            } else {
+                args.inputTokenAmount = _getSpendableERC20BalanceOf(
+                    args.inputToken,
+                    args.taker
+                );
+            }
         }
 
         TransformERC20PrivateState memory state;

--- a/contracts/zero-ex/contracts/test/TestMintTokenERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/test/TestMintTokenERC20Transformer.sol
@@ -60,11 +60,17 @@ contract TestMintTokenERC20Transformer is
             context.sender,
             context.taker,
             context.data,
-            data.inputToken.balanceOf(address(this)),
+            LibERC20Transformer.isTokenETH(data.inputToken)
+                ? address(this).balance
+                : data.inputToken.balanceOf(address(this)),
             address(this).balance
         );
         // "Burn" input tokens.
-        data.inputToken.transfer(address(0), data.burnAmount);
+        if (LibERC20Transformer.isTokenETH(data.inputToken)) {
+            address(0).transfer(data.burnAmount);
+        } else {
+            data.inputToken.transfer(address(0), data.burnAmount);
+        }
         // Mint output tokens.
         if (LibERC20Transformer.isTokenETH(IERC20TokenV06(address(data.outputToken)))) {
             context.taker.transfer(data.mintAmount);


### PR DESCRIPTION
## Description

In the `TransformERC20Feature`, when `inputTokenAmount == uint256(-1)`, we interpret this as trying to sell the taker's *entire* available balance. But we did not check if the input token was ETH. This causes reverts because `0xeeeee...` is not a token. Now we just set `inputTokenAmount = msg.value` when ETH is being sold and `inputTokenAmount == uint256(-1)`.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
