### PR TITLE
require txOrigin for RFQ orders, allow origins to register alternate …

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -29,6 +29,10 @@
             {
                 "note": "Add metatransaction support for limit orders",
                 "pr": 44
+            },
+            {
+                "note": "Require RFQ orders to specify a transaction origin, and allow approved alternative addresses",
+                "pr": 47
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -96,7 +96,7 @@ interface INativeOrdersFeature {
     /// @param origin The address doing the registration.
     /// @param addr The address being registered.
     /// @param allowed Indicates whether the address should be allowed.
-    event OriginAllowed(
+    event RfqOrderOriginAllowed(
         address origin,
         address addr,
         bool allowed
@@ -232,7 +232,7 @@ interface INativeOrdersFeature {
     ///      specifies the message sender as its txOrigin.
     /// @param origin The origin to update.
     /// @param allowed True to register, false to unregister.
-    function registerAllowedOrigin(address origin, bool allowed)
+    function registerAllowedRfqOrigin(address origin, bool allowed)
         external;
 
     /// @dev Cancel multiple limit orders. The caller must be the maker.

--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -91,6 +91,17 @@ interface INativeOrdersFeature {
         uint256 minValidSalt
     );
 
+    /// @dev Emitted when a new address is registered or unregistered to fill
+    ///      orders with a given txOrigin.
+    /// @param origin The address doing the registration.
+    /// @param addr The address being registered.
+    /// @param allowed Indicates whether the address should be allowed.
+    event OriginAllowed(
+        address origin,
+        address addr,
+        bool allowed
+    );
+
     /// @dev Transfers protocol fees from the `FeeCollector` pools into
     ///      the staking contract.
     /// @param poolIds Staking pool IDs

--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -217,6 +217,13 @@ interface INativeOrdersFeature {
     function cancelRfqOrder(LibNativeOrder.RfqOrder calldata order)
         external;
 
+    /// @dev Mark what tx.origin addresses are allowed to fill an order that
+    ///      specifies the message sender as its txOrigin.
+    /// @param origin The origin to update.
+    /// @param allowed True to register, false to unregister.
+    function registerAllowedOrigin(address origin, bool allowed)
+        external;
+
     /// @dev Cancel multiple limit orders. The caller must be the maker.
     ///      Silently succeeds if the order has already been cancelled.
     /// @param orders The limit orders.

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -570,6 +570,8 @@ contract NativeOrdersFeature is
             LibNativeOrdersStorage.getStorage();
 
         stor.originRegistry[msg.sender][origin] = allowed;
+
+        emit OriginAllowed(msg.sender, origin, allowed);
     }
 
     /// @dev Cancel all RFQ orders for a given maker and pair with a salt less

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -146,7 +146,7 @@ contract NativeOrdersFeature is
         _registerFeatureFunction(this.getLimitOrderHash.selector);
         _registerFeatureFunction(this.getRfqOrderHash.selector);
         _registerFeatureFunction(this.getProtocolFeeMultiplier.selector);
-        _registerFeatureFunction(this.registerAllowedOrigin.selector);
+        _registerFeatureFunction(this.registerAllowedRfqOrigin.selector);
         return LibMigrate.MIGRATE_SUCCESS;
     }
 
@@ -559,7 +559,7 @@ contract NativeOrdersFeature is
     ///      specifies the message sender as its txOrigin.
     /// @param origin The origin to update.
     /// @param allowed True to register, false to unregister.
-    function registerAllowedOrigin(
+    function registerAllowedRfqOrigin(
         address origin,
         bool allowed
     )
@@ -571,7 +571,7 @@ contract NativeOrdersFeature is
 
         stor.originRegistry[msg.sender][origin] = allowed;
 
-        emit OriginAllowed(msg.sender, origin, allowed);
+        emit RfqOrderOriginAllowed(msg.sender, origin, allowed);
     }
 
     /// @dev Cancel all RFQ orders for a given maker and pair with a salt less

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -882,16 +882,18 @@ contract NativeOrdersFeature is
             ).rrevert();
         }
 
-        LibNativeOrdersStorage.Storage storage stor =
-            LibNativeOrdersStorage.getStorage();
+        {
+            LibNativeOrdersStorage.Storage storage stor =
+                LibNativeOrdersStorage.getStorage();
 
-        // Must be fillable by the tx.origin.
-        if (order.txOrigin != tx.origin && !stor.originRegistry[order.txOrigin][tx.origin]) {
-            LibNativeOrdersRichErrors.OrderNotFillableByOriginError(
-                orderInfo.orderHash,
-                tx.origin,
-                order.txOrigin
-            ).rrevert();
+            // Must be fillable by the tx.origin.
+            if (order.txOrigin != tx.origin && !stor.originRegistry[order.txOrigin][tx.origin]) {
+                LibNativeOrdersRichErrors.OrderNotFillableByOriginError(
+                    orderInfo.orderHash,
+                    tx.origin,
+                    order.txOrigin
+                ).rrevert();
+            }
         }
 
         // Signature must be valid for the order.

--- a/contracts/zero-ex/contracts/src/storage/LibNativeOrdersStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibNativeOrdersStorage.sol
@@ -39,6 +39,9 @@ library LibNativeOrdersStorage {
         // for RFQ orders.
         mapping(address => mapping(address => mapping(address => uint256)))
             rfqOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
+        // For a given order origin, which tx.origin addresses are allowed to
+        // fill the order.
+        mapping(address => mapping(address => bool)) originRegistry;
     }
 
     /// @dev Get the storage bucket for this contract.

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -1120,7 +1120,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
         it('can fill an order from a different tx.origin if registered', async () => {
             const order = getTestRfqOrder();
 
-            const receipt = await zeroEx.registerAllowedOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
+            const receipt = await zeroEx.registerAllowedRfqOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
             verifyEventsFromLogs(
                 receipt.logs,
                 [
@@ -1130,7 +1130,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                         allowed: true,
                     },
                 ],
-                IZeroExEvents.OriginAllowed,
+                IZeroExEvents.RfqOrderOriginAllowed,
             );
             return fillRfqOrderAsync(order, order.takerAmount, notTaker);
         });
@@ -1138,8 +1138,8 @@ blockchainTests.resets('NativeOrdersFeature', env => {
         it('cannot fill an order with registered then unregistered tx.origin', async () => {
             const order = getTestRfqOrder();
 
-            await zeroEx.registerAllowedOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
-            const receipt = await zeroEx.registerAllowedOrigin(notTaker, false).awaitTransactionSuccessAsync({ from: taker });
+            await zeroEx.registerAllowedRfqOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
+            const receipt = await zeroEx.registerAllowedRfqOrigin(notTaker, false).awaitTransactionSuccessAsync({ from: taker });
             verifyEventsFromLogs(
                 receipt.logs,
                 [
@@ -1149,7 +1149,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                         allowed: false,
                     },
                 ],
-                IZeroExEvents.OriginAllowed,
+                IZeroExEvents.RfqOrderOriginAllowed,
             );
 
             const tx = fillRfqOrderAsync(order, order.takerAmount, notTaker);

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -1120,7 +1120,18 @@ blockchainTests.resets('NativeOrdersFeature', env => {
         it('can fill an order from a different tx.origin if registered', async () => {
             const order = getTestRfqOrder();
 
-            await zeroEx.registerAllowedOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
+            const receipt = await zeroEx.registerAllowedOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
+            verifyEventsFromLogs(
+                receipt.logs,
+                [
+                    {
+                        origin: taker,
+                        addr: notTaker,
+                        allowed: true,
+                    },
+                ],
+                IZeroExEvents.OriginAllowed,
+            );
             return fillRfqOrderAsync(order, order.takerAmount, notTaker);
         });
 
@@ -1128,7 +1139,18 @@ blockchainTests.resets('NativeOrdersFeature', env => {
             const order = getTestRfqOrder();
 
             await zeroEx.registerAllowedOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
-            await zeroEx.registerAllowedOrigin(notTaker, false).awaitTransactionSuccessAsync({ from: taker });
+            const receipt = await zeroEx.registerAllowedOrigin(notTaker, false).awaitTransactionSuccessAsync({ from: taker });
+            verifyEventsFromLogs(
+                receipt.logs,
+                [
+                    {
+                        origin: taker,
+                        addr: notTaker,
+                        allowed: false,
+                    },
+                ],
+                IZeroExEvents.OriginAllowed,
+            );
 
             const tx = fillRfqOrderAsync(order, order.takerAmount, notTaker);
             return expect(tx).to.revertWith(

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -1120,7 +1120,9 @@ blockchainTests.resets('NativeOrdersFeature', env => {
         it('can fill an order from a different tx.origin if registered', async () => {
             const order = getTestRfqOrder();
 
-            const receipt = await zeroEx.registerAllowedRfqOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
+            const receipt = await zeroEx
+                .registerAllowedRfqOrigin(notTaker, true)
+                .awaitTransactionSuccessAsync({ from: taker });
             verifyEventsFromLogs(
                 receipt.logs,
                 [
@@ -1139,7 +1141,9 @@ blockchainTests.resets('NativeOrdersFeature', env => {
             const order = getTestRfqOrder();
 
             await zeroEx.registerAllowedRfqOrigin(notTaker, true).awaitTransactionSuccessAsync({ from: taker });
-            const receipt = await zeroEx.registerAllowedRfqOrigin(notTaker, false).awaitTransactionSuccessAsync({ from: taker });
+            const receipt = await zeroEx
+                .registerAllowedRfqOrigin(notTaker, false)
+                .awaitTransactionSuccessAsync({ from: taker });
             verifyEventsFromLogs(
                 receipt.logs,
                 [


### PR DESCRIPTION
…addresses that can fill orders

## Description

RFQ orders now require that the tx.origin is either txOrigin or another address that's been specifically allowed (via `registerAllowedOrigin()`).

## Testing instructions

`yarn test`

## Types of changes

* New feature / breaking change: txOrigin == 0 no longer means RFQ orders are open to any tx.origin.

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
