### PR TITLE
feat: add takerAssetToEthRate and makerAssetToEthRate  to quote response

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "5.4.0",
+        "changes": [
+            {
+                "note": "Add `takerAssetToEthRate` and `makerAssetToEthRate` to swap quote response",
+                "pr": 49
+            }
+        ]
+    },
+    {
         "timestamp": 1607036724,
         "version": "5.3.1",
         "changes": [

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -198,6 +198,8 @@ export interface SwapQuoteBase {
     isTwoHop: boolean;
     makerTokenDecimals: number;
     takerTokenDecimals: number;
+    ethToTakerAssetRate: BigNumber;
+    ethToMakerAssetRate: BigNumber;
 }
 
 /**

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -198,8 +198,8 @@ export interface SwapQuoteBase {
     isTwoHop: boolean;
     makerTokenDecimals: number;
     takerTokenDecimals: number;
-    ethToTakerAssetRate: BigNumber;
-    ethToMakerAssetRate: BigNumber;
+    takerAssetToEthRate: BigNumber;
+    makerAssetToEthRate: BigNumber;
 }
 
 /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -543,6 +543,10 @@ export class MarketOperationUtils {
             exchangeProxyOverhead: opts.exchangeProxyOverhead || (() => ZERO_AMOUNT),
         };
 
+        // NOTE: For sell quotes input is the taker asset and for buy quotes input is the maker asset
+        const ethToTakerAssetRate = side === MarketOperation.Sell ? ethToInputRate : ethToOutputRate;
+        const ethToMakerAssetRate = side === MarketOperation.Sell ? ethToOutputRate : ethToInputRate;
+
         // Find the unoptimized best rate to calculate savings from optimizer
         const _unoptimizedPath = fillsToSortedPaths(fills, side, inputAmount, optimizerOpts)[0];
         const unoptimizedPath = _unoptimizedPath ? _unoptimizedPath.collapse(orderOpts) : undefined;
@@ -565,6 +569,8 @@ export class MarketOperationUtils {
                 marketSideLiquidity,
                 adjustedRate: bestTwoHopRate,
                 unoptimizedPath,
+                ethToTakerAssetRate,
+                ethToMakerAssetRate,
             };
         }
 
@@ -598,6 +604,8 @@ export class MarketOperationUtils {
             marketSideLiquidity,
             adjustedRate: optimalPathRate,
             unoptimizedPath,
+            ethToTakerAssetRate,
+            ethToMakerAssetRate,
         };
     }
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -544,8 +544,8 @@ export class MarketOperationUtils {
         };
 
         // NOTE: For sell quotes input is the taker asset and for buy quotes input is the maker asset
-        const ethToTakerAssetRate = side === MarketOperation.Sell ? ethToInputRate : ethToOutputRate;
-        const ethToMakerAssetRate = side === MarketOperation.Sell ? ethToOutputRate : ethToInputRate;
+        const takerAssetToEthRate = side === MarketOperation.Sell ? ethToInputRate : ethToOutputRate;
+        const makerAssetToEthRate = side === MarketOperation.Sell ? ethToOutputRate : ethToInputRate;
 
         // Find the unoptimized best rate to calculate savings from optimizer
         const _unoptimizedPath = fillsToSortedPaths(fills, side, inputAmount, optimizerOpts)[0];
@@ -569,8 +569,8 @@ export class MarketOperationUtils {
                 marketSideLiquidity,
                 adjustedRate: bestTwoHopRate,
                 unoptimizedPath,
-                ethToTakerAssetRate,
-                ethToMakerAssetRate,
+                takerAssetToEthRate,
+                makerAssetToEthRate,
             };
         }
 
@@ -604,8 +604,8 @@ export class MarketOperationUtils {
             marketSideLiquidity,
             adjustedRate: optimalPathRate,
             unoptimizedPath,
-            ethToTakerAssetRate,
-            ethToMakerAssetRate,
+            takerAssetToEthRate,
+            makerAssetToEthRate,
         };
     }
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -346,8 +346,8 @@ export interface OptimizerResult {
     marketSideLiquidity: MarketSideLiquidity;
     adjustedRate: BigNumber;
     unoptimizedPath?: CollapsedPath;
-    ethToTakerAssetRate: BigNumber;
-    ethToMakerAssetRate: BigNumber;
+    takerAssetToEthRate: BigNumber;
+    makerAssetToEthRate: BigNumber;
 }
 
 export interface OptimizerResultWithReport extends OptimizerResult {

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -346,6 +346,8 @@ export interface OptimizerResult {
     marketSideLiquidity: MarketSideLiquidity;
     adjustedRate: BigNumber;
     unoptimizedPath?: CollapsedPath;
+    ethToTakerAssetRate: BigNumber;
+    ethToMakerAssetRate: BigNumber;
 }
 
 export interface OptimizerResultWithReport extends OptimizerResult {

--- a/packages/asset-swapper/src/utils/swap_quote_calculator.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_calculator.ts
@@ -175,8 +175,8 @@ function createSwapQuote(
         quoteReport,
         sourceFlags,
         unoptimizedPath,
-        ethToTakerAssetRate,
-        ethToMakerAssetRate,
+        takerAssetToEthRate,
+        makerAssetToEthRate,
     } = optimizerResult;
     const isTwoHop = sourceFlags === SOURCE_FLAGS[ERC20BridgeSource.MultiHop];
 
@@ -210,8 +210,8 @@ function createSwapQuote(
         sourceBreakdown,
         makerTokenDecimals,
         takerTokenDecimals,
-        ethToTakerAssetRate,
-        ethToMakerAssetRate,
+        takerAssetToEthRate,
+        makerAssetToEthRate,
         quoteReport,
         isTwoHop,
     };

--- a/packages/asset-swapper/src/utils/swap_quote_calculator.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_calculator.ts
@@ -170,7 +170,14 @@ function createSwapQuote(
     gasPrice: BigNumber,
     gasSchedule: FeeSchedule,
 ): SwapQuote {
-    const { optimizedOrders, quoteReport, sourceFlags, unoptimizedPath } = optimizerResult;
+    const {
+        optimizedOrders,
+        quoteReport,
+        sourceFlags,
+        unoptimizedPath,
+        ethToTakerAssetRate,
+        ethToMakerAssetRate,
+    } = optimizerResult;
     const isTwoHop = sourceFlags === SOURCE_FLAGS[ERC20BridgeSource.MultiHop];
 
     // Calculate quote info
@@ -203,6 +210,8 @@ function createSwapQuote(
         sourceBreakdown,
         makerTokenDecimals,
         takerTokenDecimals,
+        ethToTakerAssetRate,
+        ethToMakerAssetRate,
         quoteReport,
         isTwoHop,
     };

--- a/packages/asset-swapper/test/utils/swap_quote.ts
+++ b/packages/asset-swapper/test/utils/swap_quote.ts
@@ -41,6 +41,8 @@ export async function getFullyFillableSwapQuoteWithNoFeesAsync(
         unoptimizedOrders: orders.map(order => ({ ...order, fills: [] })),
         sourceBreakdown: breakdown,
         isTwoHop: false,
+        ethToTakerAssetRate: constants.ZERO_AMOUNT,
+        ethToMakerAssetRate: constants.ZERO_AMOUNT,
     };
 
     if (operation === MarketOperation.Buy) {

--- a/packages/asset-swapper/test/utils/swap_quote.ts
+++ b/packages/asset-swapper/test/utils/swap_quote.ts
@@ -41,8 +41,8 @@ export async function getFullyFillableSwapQuoteWithNoFeesAsync(
         unoptimizedOrders: orders.map(order => ({ ...order, fills: [] })),
         sourceBreakdown: breakdown,
         isTwoHop: false,
-        ethToTakerAssetRate: constants.ZERO_AMOUNT,
-        ethToMakerAssetRate: constants.ZERO_AMOUNT,
+        takerAssetToEthRate: constants.ZERO_AMOUNT,
+        makerAssetToEthRate: constants.ZERO_AMOUNT,
     };
 
     if (operation === MarketOperation.Buy) {


### PR DESCRIPTION
## Description

Adds `takerAssetToEthRate` and `makerAssetToEthRate` to the swap quote response object, to be able to determine the ETH value of these assets for any quoted pair.

**NOTE:** Rates can sometimes be missing, in those cases a rate of `0` will be returned.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
