### PR TITLE
RFQ order with 0 txOrigin is INVALID

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -41,6 +41,10 @@
             {
                 "note": "Remove protocol fees from all RFQ orders and add `taker` field to RFQ orders",
                 "pr": 45
+            },
+            {
+                "note": "Fix getRfqOrderInfo() to return status INVALID when missing txOrigin",
+                "pr": 50
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -646,6 +646,11 @@ contract NativeOrdersFeature is
             order.salt,
             minValidSalt
         );
+
+        // Check for missing txOrigin.
+        if (order.txOrigin == address(0)) {
+            orderInfo.status = LibNativeOrder.OrderStatus.INVALID;
+        }
     }
 
     /// @dev Get the canonical hash of a limit order.

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -358,6 +358,16 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                 takerTokenFilledAmount: fillAmount,
             });
         });
+
+        it('invalid origin', async () => {
+            const order = getTestRfqOrder({ txOrigin: NULL_ADDRESS });
+            const info = await zeroEx.getRfqOrderInfo(order).callAsync();
+            assertOrderInfoEquals(info, {
+                status: OrderStatus.Invalid,
+                orderHash: order.getHash(),
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+        });
     });
 
     describe('cancelLimitOrder()', async () => {
@@ -1200,7 +1210,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
             const order = getTestRfqOrder({ txOrigin: NULL_ADDRESS });
             const tx = fillRfqOrderAsync(order, order.takerAmount, notTaker);
             return expect(tx).to.revertWith(
-                new RevertErrors.OrderNotFillableByOriginError(order.getHash(), notTaker, order.txOrigin),
+                new RevertErrors.OrderNotFillableError(order.getHash(), OrderStatus.Invalid),
             );
         });
 


### PR DESCRIPTION
## Description

`getRfqOrderInfo()` now returns a status of INVALID for an order that has `txOrigin == 0`.

## Testing instructions

`yarn test`

## Types of changes

* Bug fix

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.