### PR TITLE
[WIP] permissionless transformers with safety check and create2

### DIFF
--- a/contracts/zero-ex/contracts/src/external/TransformerDeployer.sol
+++ b/contracts/zero-ex/contracts/src/external/TransformerDeployer.sol
@@ -19,8 +19,6 @@
 pragma solidity ^0.6.5;
 pragma experimental ABIEncoderV2;
 
-import "@0x/contracts-utils/contracts/src/v06/AuthorizableV06.sol";
-
 
 /// @dev Deployer contract for ERC20 transformers.
 ///      Only authorities may call `deploy()` and `kill()`.
@@ -58,7 +56,7 @@ contract TransformerDeployer {
     /// @dev Checks whether a given address is safe to be called via
     ///      delegatecall. A contract is considered unsafe if it includes any
     ///      of the following opcodes: CALLCODE, DELEGATECALL, SELFDESTRUCT,
-    ///      SLOAD, and STORE. This code is adapted from
+    ///      CREATE, CREATE2, SLOAD, and STORE. This code is adapted from
     ///      https://github.com/dharma-eng/dharma-smart-wallet/blob/master/contracts/helpers/IndestructibleRegistry.sol
     /// @param target The address to check.
     /// @return True if the contract is considered safe for delegatecall.
@@ -101,6 +99,8 @@ contract TransformerDeployer {
                     op == 242 || // callcode
                     op == 244 || // delegatecall
                     op == 255 || // selfdestruct
+                    op == 240 || // create
+                    op == 245 || // create2
                     op == 84  || // sload
                     op == 85     // sstore
                 ) {

--- a/contracts/zero-ex/contracts/src/external/TransformerDeployer.sol
+++ b/contracts/zero-ex/contracts/src/external/TransformerDeployer.sol
@@ -22,64 +22,96 @@ pragma experimental ABIEncoderV2;
 import "@0x/contracts-utils/contracts/src/v06/AuthorizableV06.sol";
 
 
-/// @dev A contract with a `die()` function.
-interface IKillable {
-    function die(address payable ethRecipient) external;
-}
-
 /// @dev Deployer contract for ERC20 transformers.
 ///      Only authorities may call `deploy()` and `kill()`.
-contract TransformerDeployer is
-    AuthorizableV06
-{
+contract TransformerDeployer {
     /// @dev Emitted when a contract is deployed via `deploy()`.
     /// @param deployedAddress The address of the deployed contract.
-    /// @param nonce The deployment nonce.
+    /// @param salt The deployment salt.
     /// @param sender The caller of `deploy()`.
-    event Deployed(address deployedAddress, uint256 nonce, address sender);
-    /// @dev Emitted when a contract is killed via `kill()`.
-    /// @param target The address of the contract being killed..
-    /// @param sender The caller of `kill()`.
-    event Killed(address target, address sender);
+    event Deployed(address deployedAddress, bytes32 salt, address sender);
 
     // @dev The current nonce of this contract.
-    uint256 public nonce = 1;
-    // @dev Mapping of deployed contract address to deployment nonce.
-    mapping (address => uint256) public toDeploymentNonce;
-
-    /// @dev Create this contract and register authorities.
-    constructor(address[] memory initialAuthorities) public {
-        for (uint256 i = 0; i < initialAuthorities.length; ++i) {
-            _addAuthorizedAddress(initialAuthorities[i]);
-        }
-    }
+    uint256 public nonce = 0;
+    // @dev Mapping of deployed contract address to the deployment salt.
+    mapping (address => bytes32) public toDeploymentSalt;
+    // @dev Mapping of deployed contract address to the init code hash.
+    mapping (address => bytes32) public toInitCodeHash;
 
     /// @dev Deploy a new contract. Only callable by an authority.
     ///      Any attached ETH will also be forwarded.
-    function deploy(bytes memory bytecode)
+    function deploy(bytes memory bytecode, bytes32 salt)
         public
         payable
-        onlyAuthorized
         returns (address deployedAddress)
     {
-        uint256 deploymentNonce = nonce;
-        nonce += 1;
         assembly {
-            deployedAddress := create(callvalue(), add(bytecode, 32), mload(bytecode))
+            deployedAddress := create2(callvalue(), add(bytecode, 32), mload(bytecode), salt)
         }
         require(deployedAddress != address(0), 'TransformerDeployer/DEPLOY_FAILED');
-        toDeploymentNonce[deployedAddress] = deploymentNonce;
-        emit Deployed(deployedAddress, deploymentNonce, msg.sender);
+        require(isDelegateCallSafe(deployedAddress), 'TransfermDeployer/UNSAFE_CODE');
+        toDeploymentSalt[deployedAddress] = salt;
+        toInitCodeHash[deployedAddress] = keccak256(bytecode);
+        emit Deployed(deployedAddress, salt, msg.sender);
     }
 
-    /// @dev Call `die()` on a contract. Only callable by an authority.
-    /// @param target The target contract to call `die()` on.
-    /// @param ethRecipient The Recipient of any ETH locked in `target`.
-    function kill(IKillable target, address payable ethRecipient)
-        public
-        onlyAuthorized
-    {
-        target.die(ethRecipient);
-        emit Killed(address(target), msg.sender);
+    /// @dev Checks whether a given address is safe to be called via
+    ///      delegatecall. A contract is considered unsafe if it includes any
+    ///      of the following opcodes: CALLCODE, DELEGATECALL, SELFDESTRUCT,
+    ///      SLOAD, and STORE. This code is adapted from
+    ///      https://github.com/dharma-eng/dharma-smart-wallet/blob/master/contracts/helpers/IndestructibleRegistry.sol
+    /// @param target The address to check.
+    /// @return True if the contract is considered safe for delegatecall.
+    function isDelegateCallSafe(address target) public view returns (bool) {
+        uint256 size;
+        assembly { size := extcodesize(target) }
+        require(size > 0, "No code at target.");
+
+        bytes memory extcode = new bytes(size);
+        assembly {
+            extcodecopy(target, add(extcode, 32), 0, size)
+        }
+
+        // Look for any reachable, impermissible opcodes.
+        bool reachable = true;
+        for (uint256 i = 0; i < extcode.length; i++) {
+            uint8 op = uint8(extcode[i]);
+
+            // If the opcode is a PUSH, skip over the push data.
+            if (op > 95 && op < 128) { // pushN
+                i += (op - 95);
+                continue;
+            }
+
+            if (reachable) {
+                // If execution is halted, mark subsequent opcodes unreachable.
+                if (
+                    op == 254 || // invalid
+                    op == 243 || // return
+                    op == 253 || // revert
+                    op == 86  || // jump
+                    op == 0      // stop
+                ) {
+                    reachable = false;
+                    continue;
+                }
+
+                // If opcode is impermissible, contract is unsafe.
+                if (
+                    op == 242 || // callcode
+                    op == 244 || // delegatecall
+                    op == 255 || // selfdestruct
+                    op == 84  || // sload
+                    op == 85     // sstore
+                ) {
+                    return false;
+                }
+            } else if (op == 91) { // jumpdest
+                // After a JUMPDEST, opcodes are reachable again.
+                reachable = true;
+            }
+
+            return true; // no unsafe opcodes found
+        }
     }
 }

--- a/contracts/zero-ex/contracts/src/features/ITransformERC20Feature.sol
+++ b/contracts/zero-ex/contracts/src/features/ITransformERC20Feature.sol
@@ -29,10 +29,11 @@ interface ITransformERC20Feature {
 
     /// @dev Defines a transformation to run in `transformERC20()`.
     struct Transformation {
-        // The deployment nonce for the transformer.
-        // The address of the transformer contract will be derived from this
-        // value.
-        uint32 deploymentNonce;
+        // The address of the transformer contract will be derived from the
+        // initcode hash and the salt, the relevant inputs to create2.
+        bytes32 initCodeHash;
+        bytes32 salt;
+
         // Arbitrary data to pass to the transformer.
         bytes data;
     }

--- a/contracts/zero-ex/contracts/src/features/TransformERC20Feature.sol
+++ b/contracts/zero-ex/contracts/src/features/TransformERC20Feature.sol
@@ -346,7 +346,8 @@ contract TransformERC20Feature is
         // Derive the transformer address from the deployment nonce.
         address payable transformer = LibERC20Transformer.getDeployedAddress(
             transformerDeployer,
-            transformation.deploymentNonce
+            transformation.initCodeHash,
+            transformation.salt
         );
         // Call `transformer.transform()` as the wallet.
         bytes memory resultData = wallet.executeDelegateCall(

--- a/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
@@ -79,66 +79,22 @@ library LibERC20Transformer {
         return token.balanceOf(owner);
     }
 
-    /// @dev RLP-encode a 32-bit or less account nonce.
-    /// @param nonce A positive integer in the range 0 <= nonce < 2^32.
-    /// @return rlpNonce The RLP encoding.
-    function rlpEncodeNonce(uint32 nonce)
-        internal
-        pure
-        returns (bytes memory rlpNonce)
-    {
-        // See https://github.com/ethereum/wiki/wiki/RLP for RLP encoding rules.
-        if (nonce == 0) {
-            rlpNonce = new bytes(1);
-            rlpNonce[0] = 0x80;
-        } else if (nonce < 0x80) {
-            rlpNonce = new bytes(1);
-            rlpNonce[0] = byte(uint8(nonce));
-        } else if (nonce <= 0xFF) {
-            rlpNonce = new bytes(2);
-            rlpNonce[0] = 0x81;
-            rlpNonce[1] = byte(uint8(nonce));
-        } else if (nonce <= 0xFFFF) {
-            rlpNonce = new bytes(3);
-            rlpNonce[0] = 0x82;
-            rlpNonce[1] = byte(uint8((nonce & 0xFF00) >> 8));
-            rlpNonce[2] = byte(uint8(nonce));
-        } else if (nonce <= 0xFFFFFF) {
-            rlpNonce = new bytes(4);
-            rlpNonce[0] = 0x83;
-            rlpNonce[1] = byte(uint8((nonce & 0xFF0000) >> 16));
-            rlpNonce[2] = byte(uint8((nonce & 0xFF00) >> 8));
-            rlpNonce[3] = byte(uint8(nonce));
-        } else {
-            rlpNonce = new bytes(5);
-            rlpNonce[0] = 0x84;
-            rlpNonce[1] = byte(uint8((nonce & 0xFF000000) >> 24));
-            rlpNonce[2] = byte(uint8((nonce & 0xFF0000) >> 16));
-            rlpNonce[3] = byte(uint8((nonce & 0xFF00) >> 8));
-            rlpNonce[4] = byte(uint8(nonce));
-        }
-    }
-
     /// @dev Compute the expected deployment address by `deployer` at
     ///      the nonce given by `deploymentNonce`.
     /// @param deployer The address of the deployer.
-    /// @param deploymentNonce The nonce that the deployer had when deploying
-    ///        a contract.
+    /// @param initCodeHash The hash of the deployed init code.
+    /// @param salt The salt used when deploying the contract.
     /// @return deploymentAddress The deployment address.
-    function getDeployedAddress(address deployer, uint32 deploymentNonce)
+    function getDeployedAddress(address deployer, bytes32 initCodeHash, bytes32 salt)
         internal
         pure
         returns (address payable deploymentAddress)
     {
-        // The address of if a deployed contract is the lower 20 bytes of the
-        // hash of the RLP-encoded deployer's account address + account nonce.
-        // See: https://ethereum.stackexchange.com/questions/760/how-is-the-address-of-an-ethereum-contract-computed
-        bytes memory rlpNonce = rlpEncodeNonce(deploymentNonce);
-        return address(uint160(uint256(keccak256(abi.encodePacked(
-            byte(uint8(0xC0 + 21 + rlpNonce.length)),
-            byte(uint8(0x80 + 20)),
+        return address(uint256(keccak256(abi.encodePacked(
+            uint8(0xFF),
             deployer,
-            rlpNonce
-        )))));
+            salt,
+            initCodeHash
+        ))));
     }
 }

--- a/contracts/zero-ex/contracts/test/TestTransformerDeployerTransformer.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerDeployerTransformer.sol
@@ -35,23 +35,14 @@ contract TestTransformerDeployerTransformer {
         );
     }
 
-    modifier onlyDeployer() {
-        require(msg.sender == deployer, "TestTransformerDeployerTransformer/ONLY_DEPLOYER");
-        _;
-    }
-
-    function die(address payable ethRecipient)
-        external
-        onlyDeployer
-    {
-        selfdestruct(ethRecipient);
-    }
-
-    function isDeployedByDeployer(uint32 nonce)
+    function isDeployedByDeployer(bytes32 initCodeHash, bytes32 salt)
         external
         view
         returns (bool)
     {
-        return LibERC20Transformer.getDeployedAddress(deployer, nonce) == address(this);
+        return LibERC20Transformer.getDeployedAddress(
+            deployer,
+            initCodeHash,
+            salt) == address(this);
     }
 }

--- a/contracts/zero-ex/test/features/meta_transactions_test.ts
+++ b/contracts/zero-ex/test/features/meta_transactions_test.ts
@@ -138,7 +138,7 @@ blockchainTests.resets('MetaTransactions feature', env => {
         outputToken: string;
         inputTokenAmount: BigNumber;
         minOutputTokenAmount: BigNumber;
-        transformations: Array<{ deploymentNonce: BigNumber; data: string }>;
+        transformations: Array<{ initCodeHash: string; salt: string; data: string }>;
     }
 
     function getRandomTransformERC20Args(fields: Partial<TransformERC20Args> = {}): TransformERC20Args {
@@ -147,7 +147,7 @@ blockchainTests.resets('MetaTransactions feature', env => {
             outputToken: randomAddress(),
             inputTokenAmount: getRandomInteger(1, '1e18'),
             minOutputTokenAmount: getRandomInteger(1, '1e18'),
-            transformations: [{ deploymentNonce: new BigNumber(123), data: hexUtils.random() }],
+            transformations: [{ initCodeHash: hexUtils.random(), salt: hexUtils.random(), data: hexUtils.random() }],
             ...fields,
         };
     }

--- a/contracts/zero-ex/test/features/token_spender_test.ts
+++ b/contracts/zero-ex/test/features/token_spender_test.ts
@@ -22,12 +22,14 @@ blockchainTests.resets('TokenSpender feature', env => {
     before(async () => {
         const [owner] = await env.getAccountAddressesAsync();
         zeroEx = await fullMigrateAsync(owner, env.provider, env.txDefaults, {
-            tokenSpender: (await TokenSpenderFeatureContract.deployFrom0xArtifactAsync(
-                artifacts.TestTokenSpender,
-                env.provider,
-                env.txDefaults,
-                artifacts,
-            )).address,
+            tokenSpender: (
+                await TokenSpenderFeatureContract.deployFrom0xArtifactAsync(
+                    artifacts.TestTokenSpender,
+                    env.provider,
+                    env.txDefaults,
+                    artifacts,
+                )
+            ).address,
         });
         feature = new TokenSpenderFeatureContract(zeroEx.address, env.provider, env.txDefaults, abis);
         token = await TestTokenSpenderERC20TokenContract.deployFrom0xArtifactAsync(

--- a/contracts/zero-ex/test/transformer_deployer_test.ts
+++ b/contracts/zero-ex/test/transformer_deployer_test.ts
@@ -1,5 +1,6 @@
-import { blockchainTests, constants, expect, randomAddress, verifyEventsFromLogs } from '@0x/contracts-test-utils';
-import { AuthorizableRevertErrors, BigNumber } from '@0x/utils';
+import { blockchainTests, expect, verifyEventsFromLogs } from '@0x/contracts-test-utils';
+import { BigNumber, hexUtils } from '@0x/utils';
+import * as ethjs from 'ethereumjs-util';
 
 import { artifacts } from './artifacts';
 import {
@@ -10,50 +11,45 @@ import {
 
 blockchainTests.resets('TransformerDeployer', env => {
     let owner: string;
-    let authority: string;
+    let sender: string;
     let deployer: TransformerDeployerContract;
     const deployBytes = artifacts.TestTransformerDeployerTransformer.compilerOutput.evm.bytecode.object;
 
     before(async () => {
-        [owner, authority] = await env.getAccountAddressesAsync();
+        [owner, sender] = await env.getAccountAddressesAsync();
         deployer = await TransformerDeployerContract.deployFrom0xArtifactAsync(
             artifacts.TransformerDeployer,
             env.provider,
             env.txDefaults,
             artifacts,
-            [authority],
         );
     });
 
     describe('deploy()', () => {
-        it('non-authority cannot call', async () => {
-            const nonAuthority = randomAddress();
-            const tx = deployer.deploy(deployBytes).callAsync({ from: nonAuthority });
-            return expect(tx).to.revertWith(new AuthorizableRevertErrors.SenderNotAuthorizedError(nonAuthority));
-        });
-
-        it('authority can deploy', async () => {
-            const targetAddress = await deployer.deploy(deployBytes).callAsync({ from: authority });
+        it('can deploy safe contract', async () => {
+            const salt = hexUtils.random();
+            const targetAddress = await deployer.deploy(deployBytes, salt).callAsync();
             const target = new TestTransformerDeployerTransformerContract(targetAddress, env.provider);
-            const receipt = await deployer.deploy(deployBytes).awaitTransactionSuccessAsync({ from: authority });
+            const receipt = await deployer.deploy(deployBytes, salt).awaitTransactionSuccessAsync({ from: sender });
             expect(await target.deployer().callAsync()).to.eq(deployer.address);
             verifyEventsFromLogs(
                 receipt.logs,
-                [{ deployedAddress: targetAddress, nonce: new BigNumber(1), sender: authority }],
+                [{ deployedAddress: targetAddress, salt, sender }],
                 TransformerDeployerEvents.Deployed,
             );
         });
 
-        it('authority can deploy with value', async () => {
-            const targetAddress = await deployer.deploy(deployBytes).callAsync({ from: authority, value: 1 });
+        it('can deploy safe contract with value', async () => {
+            const salt = hexUtils.random();
+            const targetAddress = await deployer.deploy(deployBytes, salt).callAsync({ from: sender, value: 1 });
             const target = new TestTransformerDeployerTransformerContract(targetAddress, env.provider);
             const receipt = await deployer
-                .deploy(deployBytes)
-                .awaitTransactionSuccessAsync({ from: authority, value: 1 });
+                .deploy(deployBytes, salt)
+                .awaitTransactionSuccessAsync({ from: sender, value: 1 });
             expect(await target.deployer().callAsync()).to.eq(deployer.address);
             verifyEventsFromLogs(
                 receipt.logs,
-                [{ deployedAddress: targetAddress, nonce: new BigNumber(1), sender: authority }],
+                [{ deployedAddress: targetAddress, salt, sender }],
                 TransformerDeployerEvents.Deployed,
             );
             expect(await env.web3Wrapper.getBalanceInWeiAsync(targetAddress)).to.bignumber.eq(1);
@@ -61,58 +57,26 @@ blockchainTests.resets('TransformerDeployer', env => {
 
         it('reverts if constructor throws', async () => {
             const CONSTRUCTOR_FAIL_VALUE = new BigNumber(3333);
-            const tx = deployer.deploy(deployBytes).callAsync({ value: CONSTRUCTOR_FAIL_VALUE, from: authority });
+            const tx = deployer
+                .deploy(deployBytes, hexUtils.random())
+                .callAsync({ value: CONSTRUCTOR_FAIL_VALUE, from: sender });
             return expect(tx).to.revertWith('TransformerDeployer/DEPLOY_FAILED');
         });
 
-        it('updates nonce', async () => {
-            expect(await deployer.nonce().callAsync()).to.bignumber.eq(1);
-            await deployer.deploy(deployBytes).awaitTransactionSuccessAsync({ from: authority });
-            expect(await deployer.nonce().callAsync()).to.bignumber.eq(2);
+        it('can retrieve deployment salt from contract address', async () => {
+            const salt = hexUtils.random();
+            const targetAddress = await deployer.deploy(deployBytes, salt).callAsync({ from: sender });
+            await deployer.deploy(deployBytes, salt).awaitTransactionSuccessAsync({ from: sender });
+            expect(await deployer.toDeploymentSalt(targetAddress).callAsync()).to.eq(salt);
         });
 
-        it('nonce can predict deployment address', async () => {
-            const nonce = await deployer.nonce().callAsync();
-            const targetAddress = await deployer.deploy(deployBytes).callAsync({ from: authority });
-            const target = new TestTransformerDeployerTransformerContract(targetAddress, env.provider);
-            await deployer.deploy(deployBytes).awaitTransactionSuccessAsync({ from: authority });
-            expect(await target.isDeployedByDeployer(nonce).callAsync()).to.eq(true);
-        });
-
-        it('can retrieve deployment nonce from contract address', async () => {
-            const nonce = await deployer.nonce().callAsync();
-            const targetAddress = await deployer.deploy(deployBytes).callAsync({ from: authority });
-            await deployer.deploy(deployBytes).awaitTransactionSuccessAsync({ from: authority });
-            expect(await deployer.toDeploymentNonce(targetAddress).callAsync()).to.bignumber.eq(nonce);
-        });
-    });
-
-    describe('kill()', () => {
-        const ethRecipient = randomAddress();
-        let target: TestTransformerDeployerTransformerContract;
-
-        before(async () => {
-            const targetAddress = await deployer.deploy(deployBytes).callAsync({ from: authority });
-            target = new TestTransformerDeployerTransformerContract(targetAddress, env.provider);
-            await deployer.deploy(deployBytes).awaitTransactionSuccessAsync({ from: authority });
-        });
-
-        it('non-authority cannot call', async () => {
-            const nonAuthority = randomAddress();
-            const tx = deployer.kill(target.address, ethRecipient).callAsync({ from: nonAuthority });
-            return expect(tx).to.revertWith(new AuthorizableRevertErrors.SenderNotAuthorizedError(nonAuthority));
-        });
-
-        it('authority can kill a contract', async () => {
-            const receipt = await deployer
-                .kill(target.address, ethRecipient)
-                .awaitTransactionSuccessAsync({ from: authority });
-            verifyEventsFromLogs(
-                receipt.logs,
-                [{ target: target.address, sender: authority }],
-                TransformerDeployerEvents.Killed,
+        it('can retrieve deployment init code hash from contract address', async () => {
+            const salt = hexUtils.random();
+            const targetAddress = await deployer.deploy(deployBytes, salt).callAsync({ from: sender });
+            await deployer.deploy(deployBytes, salt).awaitTransactionSuccessAsync({ from: sender });
+            expect(hexUtils.toHex(await deployer.toInitCodeHash(targetAddress).callAsync())).to.eq(
+                hexUtils.toHex(ethjs.sha3(deployBytes)),
             );
-            return expect(env.web3Wrapper.getContractCodeAsync(target.address)).to.become(constants.NULL_BYTES);
         });
     });
 });


### PR DESCRIPTION
**STATUS**: This really needs some tests for `isDelegateCallSafe()`, so it's still a WIP, but I wanted to share early so we could course-correct if somebody doesn't like the general direction.

## Description

This change makes it possible for anyone to deploy a transformer. This is safe due to the new `isDelegateCallSafe()` function, which checks that a contract doesn't use any forbidden instructions like SELFDESTRUCT or DELEGATECALL. We also check for SLOAD and SSTORE. This isn't strictly necessary, but it helps prevent mistakes.

## Testing instructions

`yarn test`, but the actual functionality of `isDelegateCallSafe()` is largely untested so far.

## Types of changes

* New feature
* Breaking change

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.