### PR TITLE
Splits `PairOrdersCancelled` event into Limit/RFQ

### DIFF
--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -76,13 +76,26 @@ interface INativeOrdersFeature {
         address maker
     );
 
-    /// @dev Emitted whenever limit or RFQ orders are cancelled by pair by a maker.
+    /// @dev Emitted whenever Limit orders are cancelled by pair by a maker.
     /// @param maker The maker of the order.
     /// @param makerToken The maker token in a pair for the orders cancelled.
     /// @param takerToken The taker token in a pair for the orders cancelled.
     /// @param minValidSalt The new minimum valid salt an order with this pair must
     ///        have.
-    event PairOrdersCancelled(
+    event PairCancelledLimitOrders(
+        address maker,
+        address makerToken,
+        address takerToken,
+        uint256 minValidSalt
+    );
+
+    /// @dev Emitted whenever RFQ orders are cancelled by pair by a maker.
+    /// @param maker The maker of the order.
+    /// @param makerToken The maker token in a pair for the orders cancelled.
+    /// @param takerToken The taker token in a pair for the orders cancelled.
+    /// @param minValidSalt The new minimum valid salt an order with this pair must
+    ///        have.
+    event PairCancelledRfqOrders(
         address maker,
         address makerToken,
         address takerToken,

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -467,7 +467,7 @@ contract NativeOrdersFeature is
             [address(makerToken)]
             [address(takerToken)] = minValidSalt;
 
-        emit PairOrdersCancelled(
+        emit PairCancelledLimitOrders(
             msg.sender,
             address(makerToken),
             address(takerToken),
@@ -541,7 +541,7 @@ contract NativeOrdersFeature is
             [address(makerToken)]
             [address(takerToken)] = minValidSalt;
 
-        emit PairOrdersCancelled(
+        emit PairCancelledRfqOrders(
             msg.sender,
             address(makerToken),
             address(takerToken),

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -587,7 +587,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                         minValidSalt,
                     },
                 ],
-                IZeroExEvents.PairOrdersCancelled,
+                IZeroExEvents.PairCancelledLimitOrders,
             );
             const statuses = (await Promise.all(orders.map(o => zeroEx.getLimitOrderInfo(o).callAsync()))).map(
                 oi => oi.status,
@@ -624,7 +624,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                         minValidSalt,
                     },
                 ],
-                IZeroExEvents.PairOrdersCancelled,
+                IZeroExEvents.PairCancelledRfqOrders,
             );
             const statuses = (await Promise.all(orders.map(o => zeroEx.getRfqOrderInfo(o).callAsync()))).map(
                 oi => oi.status,
@@ -680,7 +680,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                         minValidSalt,
                     },
                 ],
-                IZeroExEvents.PairOrdersCancelled,
+                IZeroExEvents.PairCancelledLimitOrders,
             );
             const statuses = (await Promise.all(orders.map(o => zeroEx.getLimitOrderInfo(o).callAsync()))).map(
                 oi => oi.status,
@@ -722,7 +722,7 @@ blockchainTests.resets('NativeOrdersFeature', env => {
                         minValidSalt,
                     },
                 ],
-                IZeroExEvents.PairOrdersCancelled,
+                IZeroExEvents.PairCancelledRfqOrders,
             );
             const statuses = (await Promise.all(orders.map(o => zeroEx.getRfqOrderInfo(o).callAsync()))).map(
                 oi => oi.status,


### PR DESCRIPTION
## Description

Right now we have a single `PairOrdersCancelled` event, which is emitted when cancelling a pair for Limit or Market orders. In this PR we split this event into `PairCancelledLimitOrders` and `PairCancelledRfqOrders` so that a listener will know which order type the market was cancelled under, without having to dig into the calldata.


## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
