### PR TITLE
Remove PLP backwards-compatibility

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Always transfer `msg.value` to the liquidity provider contract in LiquidityProviderFeature to",
                 "pr": 82
+            },
+            {
+                "note": "Remove backwards compatibility with old PLP/bridge interface in `LiquidityProviderFeature` and `MixinZeroExBridge`",
+                "pr": 85
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/external/LiquidityProviderSandbox.sol
+++ b/contracts/zero-ex/contracts/src/external/LiquidityProviderSandbox.sol
@@ -68,21 +68,13 @@ contract LiquidityProviderSandbox is
         onlyOwner
         override
     {
-        try ILiquidityProvider(provider).sellTokenForToken(
+        ILiquidityProvider(provider).sellTokenForToken(
             inputToken,
             outputToken,
             recipient,
             minBuyAmount,
             auxiliaryData
-        ) {} catch {
-            IERC20Bridge(provider).bridgeTransferFrom(
-                outputToken,
-                provider,
-                recipient,
-                minBuyAmount,
-                auxiliaryData
-            );
-        }
+        );
     }
 
     /// @dev Calls `sellEthForToken` on the given `provider` contract to

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinZeroExBridge.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinZeroExBridge.sol
@@ -22,7 +22,6 @@ import "@0x/contracts-erc20/contracts/src/v06/LibERC20TokenV06.sol";
 import "@0x/contracts-erc20/contracts/src/v06/IERC20TokenV06.sol";
 import "@0x/contracts-utils/contracts/src/v06/LibSafeMathV06.sol";
 import "../../../vendor/ILiquidityProvider.sol";
-import "../../../vendor/v3/IERC20Bridge.sol";
 
 
 contract MixinZeroExBridge {
@@ -61,32 +60,20 @@ contract MixinZeroExBridge {
             bridgeAddress,
             sellAmount
         );
-        try ILiquidityProvider(bridgeAddress).sellTokenForToken(
-                address(sellToken),
-                address(buyToken),
-                address(this), // recipient
-                1, // minBuyAmount
-                bridgeData
-        ) returns (uint256 _boughtAmount) {
-            boughtAmount = _boughtAmount;
-            emit ERC20BridgeTransfer(
-                sellToken,
-                buyToken,
-                sellAmount,
-                boughtAmount,
-                bridgeAddress,
-                address(this)
-            );
-        } catch {
-            uint256 balanceBefore = buyToken.balanceOf(address(this));
-            IERC20Bridge(bridgeAddress).bridgeTransferFrom(
-                address(buyToken),
-                bridgeAddress,
-                address(this), // recipient
-                1, // minBuyAmount
-                bridgeData
-            );
-            boughtAmount = buyToken.balanceOf(address(this)).safeSub(balanceBefore);
-        }
+        boughtAmount = ILiquidityProvider(bridgeAddress).sellTokenForToken(
+            address(sellToken),
+            address(buyToken),
+            address(this), // recipient
+            1, // minBuyAmount
+            bridgeData
+        );
+        emit ERC20BridgeTransfer(
+            sellToken,
+            buyToken,
+            sellAmount,
+            boughtAmount,
+            bridgeAddress,
+            address(this)
+        );
     }
 }

--- a/contracts/zero-ex/test/features/liquidity_provider_test.ts
+++ b/contracts/zero-ex/test/features/liquidity_provider_test.ts
@@ -9,8 +9,6 @@ import { abis } from '../utils/abis';
 import { fullMigrateAsync } from '../utils/migration';
 import {
     LiquidityProviderSandboxContract,
-    TestBridgeContract,
-    TestBridgeEvents,
     TestLiquidityProviderContract,
     TestLiquidityProviderEvents,
     TestWethContract,
@@ -146,41 +144,6 @@ blockchainTests('LiquidityProvider feature', env => {
                     },
                 ],
                 TestLiquidityProviderEvents.SellTokenForToken,
-            );
-        });
-        it('Successfully executes an ERC20-ERC20 swap (backwards-compatibility)', async () => {
-            const bridge = await TestBridgeContract.deployFrom0xArtifactAsync(
-                artifacts.TestBridge,
-                env.provider,
-                env.txDefaults,
-                artifacts,
-                weth.address,
-                token.address,
-            );
-            const tx = await feature
-                .sellToLiquidityProvider(
-                    token.address,
-                    weth.address,
-                    bridge.address,
-                    constants.NULL_ADDRESS,
-                    constants.ONE_ETHER,
-                    constants.ZERO_AMOUNT,
-                    constants.NULL_BYTES,
-                )
-                .awaitTransactionSuccessAsync({ from: taker });
-            verifyEventsFromLogs(
-                tx.logs,
-                [
-                    {
-                        inputToken: token.address,
-                        outputToken: weth.address,
-                        inputTokenAmount: constants.ONE_ETHER,
-                        outputTokenAmount: constants.ZERO_AMOUNT,
-                        from: bridge.address,
-                        to: taker,
-                    },
-                ],
-                TestBridgeEvents.ERC20BridgeTransfer,
             );
         });
         it('Reverts if cannot fulfill the minimum buy amount', async () => {


### PR DESCRIPTION
## Description
All PLPs are now using the new interface. Removes backwards compatibility from `MixinZeroExBridge` and `LiquidityProviderSandbox`. This also fixes the issue of `LiquidityProviderSandbox` swallowing errors.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
