### PR TITLE
fix: Fix quote report

### DIFF
--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -675,7 +675,7 @@ export class MarketOperationUtils {
                     marketSideLiquidity = {
                         ...marketSideLiquidity,
                         rfqtIndicativeQuotes: indicativeQuotes,
-                    }
+                    };
                     optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts);
                 }
             } else if (!rfqt.isIndicative && isFirmPriceAwareEnabled) {
@@ -708,12 +708,12 @@ export class MarketOperationUtils {
                             ...marketSideLiquidity,
                             nativeOrders: marketSideLiquidity.nativeOrders.concat(firmQuoteSignedOrders),
                             orderFillableAmounts: marketSideLiquidity.orderFillableAmounts.concat(rfqOrderFillableAmounts),
-                        }
+                        };
 
                         // Re-run optimizer with the new firm quote. This is the second and last time
                         // we run the optimized in a block of code. In this case, we don't catch a potential `NoOptimalPath` exception
                         // and we let it bubble up if it happens.
-                        optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts)
+                        optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts);
                     }
                 }
             }

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -707,7 +707,9 @@ export class MarketOperationUtils {
                         marketSideLiquidity = {
                             ...marketSideLiquidity,
                             nativeOrders: marketSideLiquidity.nativeOrders.concat(firmQuoteSignedOrders),
-                            orderFillableAmounts: marketSideLiquidity.orderFillableAmounts.concat(rfqOrderFillableAmounts),
+                            orderFillableAmounts: marketSideLiquidity.orderFillableAmounts.concat(
+                                rfqOrderFillableAmounts,
+                            ),
                         };
 
                         // Re-run optimizer with the new firm quote. This is the second and last time

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -81,13 +81,12 @@ export class MarketOperationUtils {
     private readonly _feeSources = new SourceFilters(FEE_QUOTE_SOURCES);
 
     private static _computeQuoteReport(
-        nativeOrders: SignedOrder[],
         quoteRequestor: QuoteRequestor | undefined,
         marketSideLiquidity: MarketSideLiquidity,
         optimizerResult: OptimizerResult,
         comparisonPrice?: BigNumber | undefined,
     ): QuoteReport {
-        const { side, dexQuotes, twoHopQuotes, orderFillableAmounts } = marketSideLiquidity;
+        const { side, dexQuotes, twoHopQuotes, orderFillableAmounts, nativeOrders } = marketSideLiquidity;
         const { liquidityDelivered } = optimizerResult;
         return generateQuoteReport(
             side,
@@ -630,7 +629,7 @@ export class MarketOperationUtils {
             side === MarketOperation.Sell
                 ? this.getMarketSellLiquidityAsync.bind(this)
                 : this.getMarketBuyLiquidityAsync.bind(this);
-        const marketSideLiquidity: MarketSideLiquidity = await marketLiquidityFnAsync(nativeOrders, amount, _opts);
+        let marketSideLiquidity: MarketSideLiquidity = await marketLiquidityFnAsync(nativeOrders, amount, _opts);
         let optimizerResult: OptimizerResult | undefined;
         try {
             optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts);
@@ -673,13 +672,11 @@ export class MarketOperationUtils {
                 );
                 // Re-run optimizer with the new indicative quote
                 if (indicativeQuotes.length > 0) {
-                    optimizerResult = await this._generateOptimizedOrdersAsync(
-                        {
-                            ...marketSideLiquidity,
-                            rfqtIndicativeQuotes: indicativeQuotes,
-                        },
-                        optimizerOpts,
-                    );
+                    marketSideLiquidity = {
+                        ...marketSideLiquidity,
+                        rfqtIndicativeQuotes: indicativeQuotes,
+                    }
+                    optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts);
                 }
             } else if (!rfqt.isIndicative && isFirmPriceAwareEnabled) {
                 // A firm quote is being requested, and firm quotes price-aware enabled. Ensure that `intentOnFilling` is enabled.
@@ -707,19 +704,16 @@ export class MarketOperationUtils {
                                 ? firmQuoteSignedOrders.map(signedOrder => signedOrder.takerAssetAmount)
                                 : await rfqt.firmQuoteValidator.getRfqtTakerFillableAmountsAsync(firmQuoteSignedOrders);
 
+                        marketSideLiquidity = {
+                            ...marketSideLiquidity,
+                            nativeOrders: marketSideLiquidity.nativeOrders.concat(firmQuoteSignedOrders),
+                            orderFillableAmounts: marketSideLiquidity.orderFillableAmounts.concat(rfqOrderFillableAmounts),
+                        }
+
                         // Re-run optimizer with the new firm quote. This is the second and last time
                         // we run the optimized in a block of code. In this case, we don't catch a potential `NoOptimalPath` exception
                         // and we let it bubble up if it happens.
-                        optimizerResult = await this._generateOptimizedOrdersAsync(
-                            {
-                                ...marketSideLiquidity,
-                                nativeOrders: marketSideLiquidity.nativeOrders.concat(firmQuoteSignedOrders),
-                                orderFillableAmounts: marketSideLiquidity.orderFillableAmounts.concat(
-                                    rfqOrderFillableAmounts,
-                                ),
-                            },
-                            optimizerOpts,
-                        );
+                        optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts)
                     }
                 }
             }
@@ -735,7 +729,6 @@ export class MarketOperationUtils {
         let quoteReport: QuoteReport | undefined;
         if (_opts.shouldGenerateQuoteReport) {
             quoteReport = MarketOperationUtils._computeQuoteReport(
-                nativeOrders,
                 _opts.rfqt ? _opts.rfqt.quoteRequestor : undefined,
                 marketSideLiquidity,
                 optimizerResult,


### PR DESCRIPTION
Quote Reports are not being updated with RFQ information that is being acquired after the initial optimizer is run. This means that RFQ indicative and firm quotes are not properly being reported in the Quote Reporter at times.

I also refactored the function `_computeQuoteReport` to not pass in `nativeOrders`, because this field of information is already present in `marketSideLiquidity`