### PR TITLE
That time DevUtils wouldn't die

### DIFF
--- a/contracts/erc20/CHANGELOG.json
+++ b/contracts/erc20/CHANGELOG.json
@@ -1,10 +1,24 @@
 [
     {
+        "version": "3.3.0",
+        "changes": [
+            {
+                "note": "Allow for excess return data in `LibERC20TokenV06` compat* functions",
+                "pr": 97
+            }
+        ]
+    },
+    {
         "timestamp": 1608692071,
         "version": "3.2.14",
         "changes": [
             {
                 "note": "Dependencies updated"
+        "version": "3.3.0",
+        "changes": [
+            {
+                "note": "Allow for excess return data in `LibERC20TokenV06` compat* functions",
+                "pr": 97
             }
         ]
     },

--- a/contracts/erc20/CHANGELOG.json
+++ b/contracts/erc20/CHANGELOG.json
@@ -14,11 +14,6 @@
         "changes": [
             {
                 "note": "Dependencies updated"
-        "version": "3.3.0",
-        "changes": [
-            {
-                "note": "Allow for excess return data in `LibERC20TokenV06` compat* functions",
-                "pr": 97
             }
         ]
     },

--- a/contracts/erc20/contracts/src/v06/LibERC20TokenV06.sol
+++ b/contracts/erc20/contracts/src/v06/LibERC20TokenV06.sol
@@ -118,7 +118,7 @@ library LibERC20TokenV06 {
     {
         tokenDecimals = 18;
         (bool didSucceed, bytes memory resultData) = address(token).staticcall(DECIMALS_CALL_DATA);
-        if (didSucceed && resultData.length == 32) {
+        if (didSucceed && resultData.length >= 32) {
             tokenDecimals = uint8(LibBytesV06.readUint256(resultData, 0));
         }
     }
@@ -141,7 +141,7 @@ library LibERC20TokenV06 {
                 spender
             )
         );
-        if (didSucceed && resultData.length == 32) {
+        if (didSucceed && resultData.length >= 32) {
             allowance_ = LibBytesV06.readUint256(resultData, 0);
         }
     }
@@ -162,7 +162,7 @@ library LibERC20TokenV06 {
                 owner
             )
         );
-        if (didSucceed && resultData.length == 32) {
+        if (didSucceed && resultData.length >= 32) {
             balance = LibBytesV06.readUint256(resultData, 0);
         }
     }
@@ -180,7 +180,7 @@ library LibERC20TokenV06 {
         if (resultData.length == 0) {
             return true;
         }
-        if (resultData.length == 32) {
+        if (resultData.length >= 32) {
             uint256 result = LibBytesV06.readUint256(resultData, 0);
             if (result == 1) {
                 return true;

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.7.0",
+        "changes": [
+            {
+                "note": "Add `LibSafeMathV06.safeDowncastToUint128()`",
+                "pr": 97
+            }
+        ]
+    },
+    {
         "timestamp": 1608692071,
         "version": "4.6.5",
         "changes": [

--- a/contracts/utils/contracts/src/v06/LibSafeMathV06.sol
+++ b/contracts/utils/contracts/src/v06/LibSafeMathV06.sol
@@ -187,4 +187,18 @@ library LibSafeMathV06 {
     {
         return a < b ? a : b;
     }
+
+    function safeDowncastToUint128(uint256 a)
+        internal
+        pure
+        returns (uint128)
+    {
+        if (a > type(uint128).max) {
+            LibRichErrorsV06.rrevert(LibSafeMathRichErrorsV06.Uint256DowncastError(
+                LibSafeMathRichErrorsV06.DowncastErrorCodes.VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT128,
+                a
+            ));
+        }
+        return uint128(a);
+    }
 }

--- a/contracts/utils/contracts/src/v06/errors/LibSafeMathRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibSafeMathRichErrorsV06.sol
@@ -39,7 +39,8 @@ library LibSafeMathRichErrorsV06 {
     enum DowncastErrorCodes {
         VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT32,
         VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT64,
-        VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT96
+        VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT96,
+        VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT128
     }
 
     // solhint-disable func-name-mixedcase

--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -2,6 +2,7 @@
     {
         "version": "0.17.0",
         "changes": [
+            {
                 "note": "Add DevUtils-like functions to `NativeOrdersFeature`",
                 "pr": 97
             }

--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "0.17.0",
+        "changes": [
+                "note": "Add DevUtils-like functions to `NativeOrdersFeature`",
+                "pr": 97
+            }
+        ]
+    },
+    {
         "version": "0.16.0",
         "changes": [
             {

--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -346,4 +346,81 @@ interface INativeOrdersFeature {
         view
         returns (uint32 multiplier);
 
+    /// @dev Get order info, fillable amount, and signature validity for a limit order.
+    ///      Fillable amount is determined using balances and allowances of the maker.
+    /// @param order The limit order.
+    /// @param signature The order signature.
+    /// @return orderInfo Info about the order.
+    /// @return actualFillableTakerTokenAmount How much of the order is fillable
+    ///         based on maker funds, in taker tokens.
+    /// @return isSignatureValid Whether the signature is valid.
+    function getLimitOrderRelevantState(
+        LibNativeOrder.LimitOrder calldata order,
+        LibSignature.Signature calldata signature
+    )
+        external
+        view
+        returns (
+            LibNativeOrder.OrderInfo memory orderInfo,
+            uint128 actualFillableTakerTokenAmount,
+            bool isSignatureValid
+        );
+
+    /// @dev Get order info, fillable amount, and signature validity for an RFQ order.
+    ///      Fillable amount is determined using balances and allowances of the maker.
+    /// @param order The RFQ order.
+    /// @param signature The order signature.
+    /// @return orderInfo Info about the order.
+    /// @return actualFillableTakerTokenAmount How much of the order is fillable
+    ///         based on maker funds, in taker tokens.
+    /// @return isSignatureValid Whether the signature is valid.
+    function getRfqOrderRelevantState(
+        LibNativeOrder.RfqOrder calldata order,
+        LibSignature.Signature calldata signature
+    )
+        external
+        view
+        returns (
+            LibNativeOrder.OrderInfo memory orderInfo,
+            uint128 actualFillableTakerTokenAmount,
+            bool isSignatureValid
+        );
+
+    /// @dev Batch version of `getLimitOrderRelevantState()`.
+    /// @param orders The limit orders.
+    /// @param signatures The order signatures.
+    /// @return orderInfos Info about the orders.
+    /// @return actualFillableTakerTokenAmounts How much of each order is fillable
+    ///         based on maker funds, in taker tokens.
+    /// @return isSignatureValids Whether each signature is valid for the order.
+    function batchGetLimitOrderRelevantStates(
+        LibNativeOrder.LimitOrder[] calldata orders,
+        LibSignature.Signature[] calldata signatures
+    )
+        external
+        view
+        returns (
+            LibNativeOrder.OrderInfo[] memory orderInfos,
+            uint128[] memory actualFillableTakerTokenAmounts,
+            bool[] memory isSignatureValids
+        );
+
+    /// @dev Batch version of `getRfqOrderRelevantState()`.
+    /// @param orders The RFQ orders.
+    /// @param signatures The order signatures.
+    /// @return orderInfos Info about the orders.
+    /// @return actualFillableTakerTokenAmounts How much of each order is fillable
+    ///         based on maker funds, in taker tokens.
+    /// @return isSignatureValids Whether each signature is valid for the order.
+    function batchGetRfqOrderRelevantStates(
+        LibNativeOrder.RfqOrder[] calldata orders,
+        LibSignature.Signature[] calldata signatures
+    )
+        external
+        view
+        returns (
+            LibNativeOrder.OrderInfo[] memory orderInfos,
+            uint128[] memory actualFillableTakerTokenAmounts,
+            bool[] memory isSignatureValids
+        );
 }

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -920,8 +920,8 @@ contract NativeOrdersFeature is
             // Empty order.
             return 0;
         }
-        if (params.orderInfo.takerTokenFilledAmount >= params.orderTakerAmount) {
-            // Already fully filled.
+        if (params.orderInfo.status != LibNativeOrder.OrderStatus.FILLABLE) {
+            // Not fillable.
             return 0;
         }
 
@@ -941,12 +941,12 @@ contract NativeOrdersFeature is
             fillableMakerTokenAmount,
             _getSpendableERC20BalanceOf(params.makerToken, params.maker)
         );
-        // Conver to taker token amount.
-        return uint128(LibMathV06.getPartialAmountCeil(
+        // Convert to taker token amount.
+        return LibMathV06.getPartialAmountCeil(
             fillableMakerTokenAmount,
             uint256(params.orderMakerAmount),
             uint256(params.orderTakerAmount)
-        ));
+        ).safeDowncastToUint128();
     }
 
     /// @dev Cancel a limit or RFQ order directly by its order hash.

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -1422,6 +1422,22 @@ blockchainTests.resets('NativeOrdersFeature', env => {
             expect(isSignatureValid).to.eq(true);
         });
 
+        it('works with cancelled order', async () => {
+            const order = getTestLimitOrder();
+            await fundOrderMakerAsync(order);
+            await zeroEx.cancelLimitOrder(order).awaitTransactionSuccessAsync({ from: maker });
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getLimitOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Cancelled,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(0);
+            expect(isSignatureValid).to.eq(true);
+        });
+
         it('works with a bad signature', async () => {
             const order = getTestLimitOrder();
             await fundOrderMakerAsync(order);
@@ -1519,6 +1535,22 @@ blockchainTests.resets('NativeOrdersFeature', env => {
             expect(orderInfo).to.deep.eq({
                 orderHash: order.getHash(),
                 status: OrderStatus.Filled,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(0);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with cancelled order', async () => {
+            const order = getTestRfqOrder();
+            await fundOrderMakerAsync(order);
+            await zeroEx.cancelRfqOrder(order).awaitTransactionSuccessAsync({ from: maker });
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getRfqOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Cancelled,
                 takerTokenFilledAmount: ZERO_AMOUNT,
             });
             expect(fillableTakerAmount).to.bignumber.eq(0);

--- a/contracts/zero-ex/test/features/native_orders_feature_test.ts
+++ b/contracts/zero-ex/test/features/native_orders_feature_test.ts
@@ -1366,14 +1366,300 @@ blockchainTests.resets('NativeOrdersFeature', env => {
         });
     });
 
-    it.skip('RFQ gas benchmark', async () => {
-        const orders = [...new Array(2)].map(() =>
-            getTestRfqOrder({ pool: '0x0000000000000000000000000000000000000000000000000000000000000000' }),
-        );
-        // Fill one to warm up the fee pool.
-        await fillRfqOrderAsync(orders[0]);
-        const receipt = await fillRfqOrderAsync(orders[1]);
-        // tslint:disable-next-line: no-console
-        console.log(receipt.gasUsed);
+    async function fundOrderMakerAsync(
+        order: LimitOrder | RfqOrder,
+        balance: BigNumber = order.makerAmount,
+        allowance: BigNumber = order.makerAmount,
+    ): Promise<void> {
+        await makerToken.burn(maker, await makerToken.balanceOf(maker).callAsync()).awaitTransactionSuccessAsync();
+        await makerToken.mint(maker, balance).awaitTransactionSuccessAsync();
+        await makerToken.approve(zeroEx.address, allowance).awaitTransactionSuccessAsync({ from: maker });
+    }
+
+    function getFillableMakerTokenAmount(
+        order: LimitOrder | RfqOrder,
+        takerTokenFilledAmount: BigNumber = ZERO_AMOUNT,
+    ): BigNumber {
+        return order.takerAmount
+            .minus(takerTokenFilledAmount)
+            .times(order.makerAmount)
+            .div(order.takerAmount)
+            .integerValue(BigNumber.ROUND_DOWN);
+    }
+
+    function getActualFillableTakerTokenAmount(
+        order: LimitOrder | RfqOrder,
+        makerBalance: BigNumber = order.makerAmount,
+        makerAllowance: BigNumber = order.makerAmount,
+        takerTokenFilledAmount: BigNumber = ZERO_AMOUNT,
+    ): BigNumber {
+        const fillableMakerTokenAmount = getFillableMakerTokenAmount(order, takerTokenFilledAmount);
+        return BigNumber.min(fillableMakerTokenAmount, makerBalance, makerAllowance)
+            .times(order.takerAmount)
+            .div(order.makerAmount)
+            .integerValue(BigNumber.ROUND_UP);
+    }
+
+    function getRandomFraction(precision: number = 2): string {
+        return Math.random().toPrecision(precision);
+    }
+
+    describe('getLimitOrderRelevantState()', () => {
+        it('works with an empty order', async () => {
+            const order = getTestLimitOrder({
+                takerAmount: ZERO_AMOUNT,
+            });
+            await fundOrderMakerAsync(order);
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getLimitOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Filled,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(0);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with a bad signature', async () => {
+            const order = getTestLimitOrder();
+            await fundOrderMakerAsync(order);
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getLimitOrderRelevantState(
+                    order,
+                    await order.clone({ maker: notMaker }).getSignatureWithProviderAsync(env.provider),
+                )
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Fillable,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(order.takerAmount);
+            expect(isSignatureValid).to.eq(false);
+        });
+
+        it('works with an unfilled order', async () => {
+            const order = getTestLimitOrder();
+            await fundOrderMakerAsync(order);
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getLimitOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Fillable,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(order.takerAmount);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with a fully filled order', async () => {
+            const order = getTestLimitOrder();
+            // Fully Fund maker and taker.
+            await fundOrderMakerAsync(order);
+            await takerToken
+                .mint(taker, order.takerAmount.plus(order.takerTokenFeeAmount))
+                .awaitTransactionSuccessAsync();
+            await fillLimitOrderAsync(order);
+            // Partially fill the order.
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getLimitOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Filled,
+                takerTokenFilledAmount: order.takerAmount,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(0);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with an under-funded, partially-filled order', async () => {
+            const order = getTestLimitOrder();
+            // Fully Fund maker and taker.
+            await fundOrderMakerAsync(order);
+            await takerToken
+                .mint(taker, order.takerAmount.plus(order.takerTokenFeeAmount))
+                .awaitTransactionSuccessAsync();
+            // Partially fill the order.
+            const fillAmount = order.takerAmount.times(getRandomFraction()).integerValue();
+            await fillLimitOrderAsync(order, { fillAmount });
+            // Reduce maker funds to be < remaining.
+            const remainingMakerAmount = getFillableMakerTokenAmount(order, fillAmount);
+            const balance = remainingMakerAmount.times(getRandomFraction()).integerValue();
+            const allowance = remainingMakerAmount.times(getRandomFraction()).integerValue();
+            await fundOrderMakerAsync(order, balance, allowance);
+            // Get order state.
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getLimitOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Fillable,
+                takerTokenFilledAmount: fillAmount,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(
+                getActualFillableTakerTokenAmount(order, balance, allowance, fillAmount),
+            );
+            expect(isSignatureValid).to.eq(true);
+        });
+    });
+
+    describe('getRfqOrderRelevantState()', () => {
+        it('works with an empty order', async () => {
+            const order = getTestRfqOrder({
+                takerAmount: ZERO_AMOUNT,
+            });
+            await fundOrderMakerAsync(order);
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getRfqOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Filled,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(0);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with a bad signature', async () => {
+            const order = getTestRfqOrder();
+            await fundOrderMakerAsync(order);
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getRfqOrderRelevantState(
+                    order,
+                    await order.clone({ maker: notMaker }).getSignatureWithProviderAsync(env.provider),
+                )
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Fillable,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(order.takerAmount);
+            expect(isSignatureValid).to.eq(false);
+        });
+
+        it('works with an unfilled order', async () => {
+            const order = getTestRfqOrder();
+            await fundOrderMakerAsync(order);
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getRfqOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Fillable,
+                takerTokenFilledAmount: ZERO_AMOUNT,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(order.takerAmount);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with a fully filled order', async () => {
+            const order = getTestRfqOrder();
+            // Fully Fund maker and taker.
+            await fundOrderMakerAsync(order);
+            await takerToken.mint(taker, order.takerAmount);
+            await fillRfqOrderAsync(order);
+            // Partially fill the order.
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getRfqOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Filled,
+                takerTokenFilledAmount: order.takerAmount,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(0);
+            expect(isSignatureValid).to.eq(true);
+        });
+
+        it('works with an under-funded, partially-filled order', async () => {
+            const order = getTestRfqOrder();
+            // Fully Fund maker and taker.
+            await fundOrderMakerAsync(order);
+            await takerToken.mint(taker, order.takerAmount).awaitTransactionSuccessAsync();
+            // Partially fill the order.
+            const fillAmount = order.takerAmount.times(getRandomFraction()).integerValue();
+            await fillRfqOrderAsync(order, fillAmount);
+            // Reduce maker funds to be < remaining.
+            const remainingMakerAmount = getFillableMakerTokenAmount(order, fillAmount);
+            const balance = remainingMakerAmount.times(getRandomFraction()).integerValue();
+            const allowance = remainingMakerAmount.times(getRandomFraction()).integerValue();
+            await fundOrderMakerAsync(order, balance, allowance);
+            // Get order state.
+            const [orderInfo, fillableTakerAmount, isSignatureValid] = await zeroEx
+                .getRfqOrderRelevantState(order, await order.getSignatureWithProviderAsync(env.provider))
+                .callAsync();
+            expect(orderInfo).to.deep.eq({
+                orderHash: order.getHash(),
+                status: OrderStatus.Fillable,
+                takerTokenFilledAmount: fillAmount,
+            });
+            expect(fillableTakerAmount).to.bignumber.eq(
+                getActualFillableTakerTokenAmount(order, balance, allowance, fillAmount),
+            );
+            expect(isSignatureValid).to.eq(true);
+        });
+    });
+
+    async function batchFundOrderMakerAsync(orders: Array<LimitOrder | RfqOrder>): Promise<void> {
+        await makerToken.burn(maker, await makerToken.balanceOf(maker).callAsync()).awaitTransactionSuccessAsync();
+        const balance = BigNumber.sum(...orders.map(o => o.makerAmount));
+        await makerToken.mint(maker, balance).awaitTransactionSuccessAsync();
+        await makerToken.approve(zeroEx.address, balance).awaitTransactionSuccessAsync({ from: maker });
+    }
+
+    describe('batchGetLimitOrderRelevantStates()', () => {
+        it('works with multiple orders', async () => {
+            const orders = new Array(3).fill(0).map(() => getTestLimitOrder());
+            await batchFundOrderMakerAsync(orders);
+            const [orderInfos, fillableTakerAmounts, isSignatureValids] = await zeroEx
+                .batchGetLimitOrderRelevantStates(
+                    orders,
+                    await Promise.all(orders.map(async o => o.getSignatureWithProviderAsync(env.provider))),
+                )
+                .callAsync();
+            expect(orderInfos).to.be.length(orders.length);
+            expect(fillableTakerAmounts).to.be.length(orders.length);
+            expect(isSignatureValids).to.be.length(orders.length);
+            for (let i = 0; i < orders.length; ++i) {
+                expect(orderInfos[i]).to.deep.eq({
+                    orderHash: orders[i].getHash(),
+                    status: OrderStatus.Fillable,
+                    takerTokenFilledAmount: ZERO_AMOUNT,
+                });
+                expect(fillableTakerAmounts[i]).to.bignumber.eq(orders[i].takerAmount);
+                expect(isSignatureValids[i]).to.eq(true);
+            }
+        });
+    });
+
+    describe('batchGetRfqOrderRelevantStates()', () => {
+        it('works with multiple orders', async () => {
+            const orders = new Array(3).fill(0).map(() => getTestRfqOrder());
+            await batchFundOrderMakerAsync(orders);
+            const [orderInfos, fillableTakerAmounts, isSignatureValids] = await zeroEx
+                .batchGetRfqOrderRelevantStates(
+                    orders,
+                    await Promise.all(orders.map(async o => o.getSignatureWithProviderAsync(env.provider))),
+                )
+                .callAsync();
+            expect(orderInfos).to.be.length(orders.length);
+            expect(fillableTakerAmounts).to.be.length(orders.length);
+            expect(isSignatureValids).to.be.length(orders.length);
+            for (let i = 0; i < orders.length; ++i) {
+                expect(orderInfos[i]).to.deep.eq({
+                    orderHash: orders[i].getHash(),
+                    status: OrderStatus.Fillable,
+                    takerTokenFilledAmount: ZERO_AMOUNT,
+                });
+                expect(fillableTakerAmounts[i]).to.bignumber.eq(orders[i].takerAmount);
+                expect(isSignatureValids[i]).to.eq(true);
+            }
+        });
     });
 });

--- a/packages/contract-artifacts/CHANGELOG.json
+++ b/packages/contract-artifacts/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.11.0",
+        "changes": [
+            {
+                "note": "Update IZeroEx artifact",
+                "pr": 97
+            }
+        ]
+    },
+    {
         "version": "3.10.0",
         "changes": [
             {

--- a/packages/contract-artifacts/artifacts/IZeroEx.json
+++ b/packages/contract-artifacts/artifacts/IZeroEx.json
@@ -474,6 +474,114 @@
                             { "internalType": "uint64", "name": "expiry", "type": "uint64" },
                             { "internalType": "uint256", "name": "salt", "type": "uint256" }
                         ],
+                        "internalType": "struct LibNativeOrder.LimitOrder[]",
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "enum LibSignature.SignatureType",
+                                "name": "signatureType",
+                                "type": "uint8"
+                            },
+                            { "internalType": "uint8", "name": "v", "type": "uint8" },
+                            { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+                            { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+                        ],
+                        "internalType": "struct LibSignature.Signature[]",
+                        "name": "signatures",
+                        "type": "tuple[]"
+                    }
+                ],
+                "name": "batchGetLimitOrderRelevantStates",
+                "outputs": [
+                    {
+                        "components": [
+                            { "internalType": "bytes32", "name": "orderHash", "type": "bytes32" },
+                            { "internalType": "enum LibNativeOrder.OrderStatus", "name": "status", "type": "uint8" },
+                            { "internalType": "uint128", "name": "takerTokenFilledAmount", "type": "uint128" }
+                        ],
+                        "internalType": "struct LibNativeOrder.OrderInfo[]",
+                        "name": "orderInfos",
+                        "type": "tuple[]"
+                    },
+                    { "internalType": "uint128[]", "name": "actualFillableTakerTokenAmounts", "type": "uint128[]" },
+                    { "internalType": "bool[]", "name": "isSignatureValids", "type": "bool[]" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "components": [
+                            { "internalType": "contract IERC20TokenV06", "name": "makerToken", "type": "address" },
+                            { "internalType": "contract IERC20TokenV06", "name": "takerToken", "type": "address" },
+                            { "internalType": "uint128", "name": "makerAmount", "type": "uint128" },
+                            { "internalType": "uint128", "name": "takerAmount", "type": "uint128" },
+                            { "internalType": "address", "name": "maker", "type": "address" },
+                            { "internalType": "address", "name": "taker", "type": "address" },
+                            { "internalType": "address", "name": "txOrigin", "type": "address" },
+                            { "internalType": "bytes32", "name": "pool", "type": "bytes32" },
+                            { "internalType": "uint64", "name": "expiry", "type": "uint64" },
+                            { "internalType": "uint256", "name": "salt", "type": "uint256" }
+                        ],
+                        "internalType": "struct LibNativeOrder.RfqOrder[]",
+                        "name": "orders",
+                        "type": "tuple[]"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "enum LibSignature.SignatureType",
+                                "name": "signatureType",
+                                "type": "uint8"
+                            },
+                            { "internalType": "uint8", "name": "v", "type": "uint8" },
+                            { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+                            { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+                        ],
+                        "internalType": "struct LibSignature.Signature[]",
+                        "name": "signatures",
+                        "type": "tuple[]"
+                    }
+                ],
+                "name": "batchGetRfqOrderRelevantStates",
+                "outputs": [
+                    {
+                        "components": [
+                            { "internalType": "bytes32", "name": "orderHash", "type": "bytes32" },
+                            { "internalType": "enum LibNativeOrder.OrderStatus", "name": "status", "type": "uint8" },
+                            { "internalType": "uint128", "name": "takerTokenFilledAmount", "type": "uint128" }
+                        ],
+                        "internalType": "struct LibNativeOrder.OrderInfo[]",
+                        "name": "orderInfos",
+                        "type": "tuple[]"
+                    },
+                    { "internalType": "uint128[]", "name": "actualFillableTakerTokenAmounts", "type": "uint128[]" },
+                    { "internalType": "bool[]", "name": "isSignatureValids", "type": "bool[]" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "components": [
+                            { "internalType": "contract IERC20TokenV06", "name": "makerToken", "type": "address" },
+                            { "internalType": "contract IERC20TokenV06", "name": "takerToken", "type": "address" },
+                            { "internalType": "uint128", "name": "makerAmount", "type": "uint128" },
+                            { "internalType": "uint128", "name": "takerAmount", "type": "uint128" },
+                            { "internalType": "uint128", "name": "takerTokenFeeAmount", "type": "uint128" },
+                            { "internalType": "address", "name": "maker", "type": "address" },
+                            { "internalType": "address", "name": "taker", "type": "address" },
+                            { "internalType": "address", "name": "sender", "type": "address" },
+                            { "internalType": "address", "name": "feeRecipient", "type": "address" },
+                            { "internalType": "bytes32", "name": "pool", "type": "bytes32" },
+                            { "internalType": "uint64", "name": "expiry", "type": "uint64" },
+                            { "internalType": "uint256", "name": "salt", "type": "uint256" }
+                        ],
                         "internalType": "struct LibNativeOrder.LimitOrder",
                         "name": "order",
                         "type": "tuple"
@@ -838,6 +946,61 @@
                 "inputs": [
                     {
                         "components": [
+                            { "internalType": "contract IERC20TokenV06", "name": "makerToken", "type": "address" },
+                            { "internalType": "contract IERC20TokenV06", "name": "takerToken", "type": "address" },
+                            { "internalType": "uint128", "name": "makerAmount", "type": "uint128" },
+                            { "internalType": "uint128", "name": "takerAmount", "type": "uint128" },
+                            { "internalType": "uint128", "name": "takerTokenFeeAmount", "type": "uint128" },
+                            { "internalType": "address", "name": "maker", "type": "address" },
+                            { "internalType": "address", "name": "taker", "type": "address" },
+                            { "internalType": "address", "name": "sender", "type": "address" },
+                            { "internalType": "address", "name": "feeRecipient", "type": "address" },
+                            { "internalType": "bytes32", "name": "pool", "type": "bytes32" },
+                            { "internalType": "uint64", "name": "expiry", "type": "uint64" },
+                            { "internalType": "uint256", "name": "salt", "type": "uint256" }
+                        ],
+                        "internalType": "struct LibNativeOrder.LimitOrder",
+                        "name": "order",
+                        "type": "tuple"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "enum LibSignature.SignatureType",
+                                "name": "signatureType",
+                                "type": "uint8"
+                            },
+                            { "internalType": "uint8", "name": "v", "type": "uint8" },
+                            { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+                            { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+                        ],
+                        "internalType": "struct LibSignature.Signature",
+                        "name": "signature",
+                        "type": "tuple"
+                    }
+                ],
+                "name": "getLimitOrderRelevantState",
+                "outputs": [
+                    {
+                        "components": [
+                            { "internalType": "bytes32", "name": "orderHash", "type": "bytes32" },
+                            { "internalType": "enum LibNativeOrder.OrderStatus", "name": "status", "type": "uint8" },
+                            { "internalType": "uint128", "name": "takerTokenFilledAmount", "type": "uint128" }
+                        ],
+                        "internalType": "struct LibNativeOrder.OrderInfo",
+                        "name": "orderInfo",
+                        "type": "tuple"
+                    },
+                    { "internalType": "uint128", "name": "actualFillableTakerTokenAmount", "type": "uint128" },
+                    { "internalType": "bool", "name": "isSignatureValid", "type": "bool" }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "components": [
                             { "internalType": "address payable", "name": "signer", "type": "address" },
                             { "internalType": "address", "name": "sender", "type": "address" },
                             { "internalType": "uint256", "name": "minGasPrice", "type": "uint256" },
@@ -962,6 +1125,59 @@
                         "name": "orderInfo",
                         "type": "tuple"
                     }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "components": [
+                            { "internalType": "contract IERC20TokenV06", "name": "makerToken", "type": "address" },
+                            { "internalType": "contract IERC20TokenV06", "name": "takerToken", "type": "address" },
+                            { "internalType": "uint128", "name": "makerAmount", "type": "uint128" },
+                            { "internalType": "uint128", "name": "takerAmount", "type": "uint128" },
+                            { "internalType": "address", "name": "maker", "type": "address" },
+                            { "internalType": "address", "name": "taker", "type": "address" },
+                            { "internalType": "address", "name": "txOrigin", "type": "address" },
+                            { "internalType": "bytes32", "name": "pool", "type": "bytes32" },
+                            { "internalType": "uint64", "name": "expiry", "type": "uint64" },
+                            { "internalType": "uint256", "name": "salt", "type": "uint256" }
+                        ],
+                        "internalType": "struct LibNativeOrder.RfqOrder",
+                        "name": "order",
+                        "type": "tuple"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "enum LibSignature.SignatureType",
+                                "name": "signatureType",
+                                "type": "uint8"
+                            },
+                            { "internalType": "uint8", "name": "v", "type": "uint8" },
+                            { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+                            { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+                        ],
+                        "internalType": "struct LibSignature.Signature",
+                        "name": "signature",
+                        "type": "tuple"
+                    }
+                ],
+                "name": "getRfqOrderRelevantState",
+                "outputs": [
+                    {
+                        "components": [
+                            { "internalType": "bytes32", "name": "orderHash", "type": "bytes32" },
+                            { "internalType": "enum LibNativeOrder.OrderStatus", "name": "status", "type": "uint8" },
+                            { "internalType": "uint128", "name": "takerTokenFilledAmount", "type": "uint128" }
+                        ],
+                        "internalType": "struct LibNativeOrder.OrderInfo",
+                        "name": "orderInfo",
+                        "type": "tuple"
+                    },
+                    { "internalType": "uint128", "name": "actualFillableTakerTokenAmount", "type": "uint128" },
+                    { "internalType": "bool", "name": "isSignatureValid", "type": "bool" }
                 ],
                 "stateMutability": "view",
                 "type": "function"
@@ -1230,6 +1446,24 @@
                     },
                     "returns": { "returnResults": "The ABI-encoded results of the underlying calls." }
                 },
+                "batchGetLimitOrderRelevantStates((address,address,uint128,uint128,uint128,address,address,address,address,bytes32,uint64,uint256)[],(uint8,uint8,bytes32,bytes32)[])": {
+                    "details": "Batch version of `getLimitOrderRelevantState()`.",
+                    "params": { "orders": "The limit orders.", "signatures": "The order signatures." },
+                    "returns": {
+                        "actualFillableTakerTokenAmounts": "How much of each order is fillable         based on maker funds, in taker tokens.",
+                        "isSignatureValids": "Whether each signature is valid for the order.",
+                        "orderInfos": "Info about the orders."
+                    }
+                },
+                "batchGetRfqOrderRelevantStates((address,address,uint128,uint128,address,address,address,bytes32,uint64,uint256)[],(uint8,uint8,bytes32,bytes32)[])": {
+                    "details": "Batch version of `getRfqOrderRelevantState()`.",
+                    "params": { "orders": "The RFQ orders.", "signatures": "The order signatures." },
+                    "returns": {
+                        "actualFillableTakerTokenAmounts": "How much of each order is fillable         based on maker funds, in taker tokens.",
+                        "isSignatureValids": "Whether each signature is valid for the order.",
+                        "orderInfos": "Info about the orders."
+                    }
+                },
                 "cancelLimitOrder((address,address,uint128,uint128,uint128,address,address,address,address,bytes32,uint64,uint256))": {
                     "details": "Cancel a single limit order. The caller must be the maker.      Silently succeeds if the order has already been cancelled.",
                     "params": { "order": "The limit order." }
@@ -1326,6 +1560,15 @@
                     "params": { "order": "The limit order." },
                     "returns": { "orderInfo": "Info about the order." }
                 },
+                "getLimitOrderRelevantState((address,address,uint128,uint128,uint128,address,address,address,address,bytes32,uint64,uint256),(uint8,uint8,bytes32,bytes32))": {
+                    "details": "Get order info, fillable amount, and signature validity for a limit order.      Fillable amount is determined using balances and allowances of the maker.",
+                    "params": { "order": "The limit order.", "signature": "The order signature." },
+                    "returns": {
+                        "actualFillableTakerTokenAmount": "How much of the order is fillable         based on maker funds, in taker tokens.",
+                        "isSignatureValid": "Whether the signature is valid.",
+                        "orderInfo": "Info about the order."
+                    }
+                },
                 "getMetaTransactionExecutedBlock((address,address,uint256,uint256,uint256,uint256,bytes,uint256,address,uint256))": {
                     "details": "Get the block at which a meta-transaction has been executed.",
                     "params": { "mtx": "The meta-transaction." },
@@ -1358,6 +1601,15 @@
                     "details": "Get the order info for an RFQ order.",
                     "params": { "order": "The RFQ order." },
                     "returns": { "orderInfo": "Info about the order." }
+                },
+                "getRfqOrderRelevantState((address,address,uint128,uint128,address,address,address,bytes32,uint64,uint256),(uint8,uint8,bytes32,bytes32))": {
+                    "details": "Get order info, fillable amount, and signature validity for an RFQ order.      Fillable amount is determined using balances and allowances of the maker.",
+                    "params": { "order": "The RFQ order.", "signature": "The order signature." },
+                    "returns": {
+                        "actualFillableTakerTokenAmount": "How much of the order is fillable         based on maker funds, in taker tokens.",
+                        "isSignatureValid": "Whether the signature is valid.",
+                        "orderInfo": "Info about the order."
+                    }
                 },
                 "getRollbackEntryAtIndex(bytes4,uint256)": {
                     "details": "Retrieve an entry in the rollback history for a function.",

--- a/packages/contract-wrappers/CHANGELOG.json
+++ b/packages/contract-wrappers/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "13.12.0",
+        "changes": [
+            {
+                "note": "Update IZeroExContract wrapper",
+                "pr": 97
+            }
+        ]
+    },
+    {
         "timestamp": 1608692071,
         "version": "13.11.2",
         "changes": [

--- a/packages/contract-wrappers/src/generated-wrappers/i_zero_ex.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_zero_ex.ts
@@ -1232,6 +1232,220 @@ export class IZeroExContract extends BaseContract {
             {
                 inputs: [
                     {
+                        name: 'orders',
+                        type: 'tuple[]',
+                        components: [
+                            {
+                                name: 'makerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'takerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'makerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'takerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'takerTokenFeeAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'maker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'taker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'sender',
+                                type: 'address',
+                            },
+                            {
+                                name: 'feeRecipient',
+                                type: 'address',
+                            },
+                            {
+                                name: 'pool',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'expiry',
+                                type: 'uint64',
+                            },
+                            {
+                                name: 'salt',
+                                type: 'uint256',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'signatures',
+                        type: 'tuple[]',
+                        components: [
+                            {
+                                name: 'signatureType',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'v',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'r',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 's',
+                                type: 'bytes32',
+                            },
+                        ],
+                    },
+                ],
+                name: 'batchGetLimitOrderRelevantStates',
+                outputs: [
+                    {
+                        name: 'orderInfos',
+                        type: 'tuple[]',
+                        components: [
+                            {
+                                name: 'orderHash',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'status',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'takerTokenFilledAmount',
+                                type: 'uint128',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'actualFillableTakerTokenAmounts',
+                        type: 'uint128[]',
+                    },
+                    {
+                        name: 'isSignatureValids',
+                        type: 'bool[]',
+                    },
+                ],
+                stateMutability: 'view',
+                type: 'function',
+            },
+            {
+                inputs: [
+                    {
+                        name: 'orders',
+                        type: 'tuple[]',
+                        components: [
+                            {
+                                name: 'makerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'takerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'makerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'takerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'maker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'taker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'txOrigin',
+                                type: 'address',
+                            },
+                            {
+                                name: 'pool',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'expiry',
+                                type: 'uint64',
+                            },
+                            {
+                                name: 'salt',
+                                type: 'uint256',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'signatures',
+                        type: 'tuple[]',
+                        components: [
+                            {
+                                name: 'signatureType',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'v',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'r',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 's',
+                                type: 'bytes32',
+                            },
+                        ],
+                    },
+                ],
+                name: 'batchGetRfqOrderRelevantStates',
+                outputs: [
+                    {
+                        name: 'orderInfos',
+                        type: 'tuple[]',
+                        components: [
+                            {
+                                name: 'orderHash',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'status',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'takerTokenFilledAmount',
+                                type: 'uint128',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'actualFillableTakerTokenAmounts',
+                        type: 'uint128[]',
+                    },
+                    {
+                        name: 'isSignatureValids',
+                        type: 'bool[]',
+                    },
+                ],
+                stateMutability: 'view',
+                type: 'function',
+            },
+            {
+                inputs: [
+                    {
                         name: 'order',
                         type: 'tuple',
                         components: [
@@ -2021,6 +2235,117 @@ export class IZeroExContract extends BaseContract {
             {
                 inputs: [
                     {
+                        name: 'order',
+                        type: 'tuple',
+                        components: [
+                            {
+                                name: 'makerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'takerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'makerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'takerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'takerTokenFeeAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'maker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'taker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'sender',
+                                type: 'address',
+                            },
+                            {
+                                name: 'feeRecipient',
+                                type: 'address',
+                            },
+                            {
+                                name: 'pool',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'expiry',
+                                type: 'uint64',
+                            },
+                            {
+                                name: 'salt',
+                                type: 'uint256',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'signature',
+                        type: 'tuple',
+                        components: [
+                            {
+                                name: 'signatureType',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'v',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'r',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 's',
+                                type: 'bytes32',
+                            },
+                        ],
+                    },
+                ],
+                name: 'getLimitOrderRelevantState',
+                outputs: [
+                    {
+                        name: 'orderInfo',
+                        type: 'tuple',
+                        components: [
+                            {
+                                name: 'orderHash',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'status',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'takerTokenFilledAmount',
+                                type: 'uint128',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'actualFillableTakerTokenAmount',
+                        type: 'uint128',
+                    },
+                    {
+                        name: 'isSignatureValid',
+                        type: 'bool',
+                    },
+                ],
+                stateMutability: 'view',
+                type: 'function',
+            },
+            {
+                inputs: [
+                    {
                         name: 'mtx',
                         type: 'tuple',
                         components: [
@@ -2304,6 +2629,109 @@ export class IZeroExContract extends BaseContract {
                                 type: 'uint128',
                             },
                         ],
+                    },
+                ],
+                stateMutability: 'view',
+                type: 'function',
+            },
+            {
+                inputs: [
+                    {
+                        name: 'order',
+                        type: 'tuple',
+                        components: [
+                            {
+                                name: 'makerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'takerToken',
+                                type: 'address',
+                            },
+                            {
+                                name: 'makerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'takerAmount',
+                                type: 'uint128',
+                            },
+                            {
+                                name: 'maker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'taker',
+                                type: 'address',
+                            },
+                            {
+                                name: 'txOrigin',
+                                type: 'address',
+                            },
+                            {
+                                name: 'pool',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'expiry',
+                                type: 'uint64',
+                            },
+                            {
+                                name: 'salt',
+                                type: 'uint256',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'signature',
+                        type: 'tuple',
+                        components: [
+                            {
+                                name: 'signatureType',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'v',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'r',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 's',
+                                type: 'bytes32',
+                            },
+                        ],
+                    },
+                ],
+                name: 'getRfqOrderRelevantState',
+                outputs: [
+                    {
+                        name: 'orderInfo',
+                        type: 'tuple',
+                        components: [
+                            {
+                                name: 'orderHash',
+                                type: 'bytes32',
+                            },
+                            {
+                                name: 'status',
+                                type: 'uint8',
+                            },
+                            {
+                                name: 'takerTokenFilledAmount',
+                                type: 'uint128',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'actualFillableTakerTokenAmount',
+                        type: 'uint128',
+                    },
+                    {
+                        name: 'isSignatureValid',
+                        type: 'bool',
                     },
                 ],
                 stateMutability: 'view',
@@ -3430,6 +3858,178 @@ export class IZeroExContract extends BaseContract {
         };
     }
     /**
+     * Batch version of `getLimitOrderRelevantState()`.
+     * @param orders The limit orders.
+     * @param signatures The order signatures.
+     */
+    public batchGetLimitOrderRelevantStates(
+        orders: Array<{
+            makerToken: string;
+            takerToken: string;
+            makerAmount: BigNumber;
+            takerAmount: BigNumber;
+            takerTokenFeeAmount: BigNumber;
+            maker: string;
+            taker: string;
+            sender: string;
+            feeRecipient: string;
+            pool: string;
+            expiry: BigNumber;
+            salt: BigNumber;
+        }>,
+        signatures: Array<{ signatureType: number | BigNumber; v: number | BigNumber; r: string; s: string }>,
+    ): ContractTxFunctionObj<
+        [Array<{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }>, BigNumber[], boolean[]]
+    > {
+        const self = (this as any) as IZeroExContract;
+        assert.isArray('orders', orders);
+        assert.isArray('signatures', signatures);
+        const functionSignature =
+            'batchGetLimitOrderRelevantStates((address,address,uint128,uint128,uint128,address,address,address,address,bytes32,uint64,uint256)[],(uint8,uint8,bytes32,bytes32)[])';
+
+        return {
+            async sendTransactionAsync(
+                txData?: Partial<TxData> | undefined,
+                opts: SendTransactionOpts = { shouldValidate: true },
+            ): Promise<string> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync(
+                    { data: this.getABIEncodedTransactionData(), ...txData },
+                    this.estimateGasAsync.bind(this),
+                );
+                if (opts.shouldValidate !== false) {
+                    await this.callAsync(txDataWithDefaults);
+                }
+                return self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            },
+            awaitTransactionSuccessAsync(
+                txData?: Partial<TxData>,
+                opts: AwaitTransactionSuccessOpts = { shouldValidate: true },
+            ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
+                return self._promiseWithTransactionHash(this.sendTransactionAsync(txData, opts), opts);
+            },
+            async estimateGasAsync(txData?: Partial<TxData> | undefined): Promise<number> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync({
+                    data: this.getABIEncodedTransactionData(),
+                    ...txData,
+                });
+                return self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            },
+            async callAsync(
+                callData: Partial<CallData> = {},
+                defaultBlock?: BlockParam,
+            ): Promise<
+                [
+                    Array<{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }>,
+                    BigNumber[],
+                    boolean[]
+                ]
+            > {
+                BaseContract._assertCallParams(callData, defaultBlock);
+                const rawCallResult = await self._performCallAsync(
+                    { data: this.getABIEncodedTransactionData(), ...callData },
+                    defaultBlock,
+                );
+                const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
+                return abiEncoder.strictDecodeReturnValue<
+                    [
+                        Array<{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }>,
+                        BigNumber[],
+                        boolean[]
+                    ]
+                >(rawCallResult);
+            },
+            getABIEncodedTransactionData(): string {
+                return self._strictEncodeArguments(functionSignature, [orders, signatures]);
+            },
+        };
+    }
+    /**
+     * Batch version of `getRfqOrderRelevantState()`.
+     * @param orders The RFQ orders.
+     * @param signatures The order signatures.
+     */
+    public batchGetRfqOrderRelevantStates(
+        orders: Array<{
+            makerToken: string;
+            takerToken: string;
+            makerAmount: BigNumber;
+            takerAmount: BigNumber;
+            maker: string;
+            taker: string;
+            txOrigin: string;
+            pool: string;
+            expiry: BigNumber;
+            salt: BigNumber;
+        }>,
+        signatures: Array<{ signatureType: number | BigNumber; v: number | BigNumber; r: string; s: string }>,
+    ): ContractTxFunctionObj<
+        [Array<{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }>, BigNumber[], boolean[]]
+    > {
+        const self = (this as any) as IZeroExContract;
+        assert.isArray('orders', orders);
+        assert.isArray('signatures', signatures);
+        const functionSignature =
+            'batchGetRfqOrderRelevantStates((address,address,uint128,uint128,address,address,address,bytes32,uint64,uint256)[],(uint8,uint8,bytes32,bytes32)[])';
+
+        return {
+            async sendTransactionAsync(
+                txData?: Partial<TxData> | undefined,
+                opts: SendTransactionOpts = { shouldValidate: true },
+            ): Promise<string> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync(
+                    { data: this.getABIEncodedTransactionData(), ...txData },
+                    this.estimateGasAsync.bind(this),
+                );
+                if (opts.shouldValidate !== false) {
+                    await this.callAsync(txDataWithDefaults);
+                }
+                return self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            },
+            awaitTransactionSuccessAsync(
+                txData?: Partial<TxData>,
+                opts: AwaitTransactionSuccessOpts = { shouldValidate: true },
+            ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
+                return self._promiseWithTransactionHash(this.sendTransactionAsync(txData, opts), opts);
+            },
+            async estimateGasAsync(txData?: Partial<TxData> | undefined): Promise<number> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync({
+                    data: this.getABIEncodedTransactionData(),
+                    ...txData,
+                });
+                return self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            },
+            async callAsync(
+                callData: Partial<CallData> = {},
+                defaultBlock?: BlockParam,
+            ): Promise<
+                [
+                    Array<{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }>,
+                    BigNumber[],
+                    boolean[]
+                ]
+            > {
+                BaseContract._assertCallParams(callData, defaultBlock);
+                const rawCallResult = await self._performCallAsync(
+                    { data: this.getABIEncodedTransactionData(), ...callData },
+                    defaultBlock,
+                );
+                const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
+                return abiEncoder.strictDecodeReturnValue<
+                    [
+                        Array<{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }>,
+                        BigNumber[],
+                        boolean[]
+                    ]
+                >(rawCallResult);
+            },
+            getABIEncodedTransactionData(): string {
+                return self._strictEncodeArguments(functionSignature, [orders, signatures]);
+            },
+        };
+    }
+    /**
      * Cancel a single limit order. The caller must be the maker.
      * Silently succeeds if the order has already been cancelled.
      * @param order The limit order.
@@ -4347,6 +4947,83 @@ export class IZeroExContract extends BaseContract {
         };
     }
     /**
+     * Get order info, fillable amount, and signature validity for a limit order.
+     * Fillable amount is determined using balances and allowances of the maker.
+     * @param order The limit order.
+     * @param signature The order signature.
+     */
+    public getLimitOrderRelevantState(
+        order: {
+            makerToken: string;
+            takerToken: string;
+            makerAmount: BigNumber;
+            takerAmount: BigNumber;
+            takerTokenFeeAmount: BigNumber;
+            maker: string;
+            taker: string;
+            sender: string;
+            feeRecipient: string;
+            pool: string;
+            expiry: BigNumber;
+            salt: BigNumber;
+        },
+        signature: { signatureType: number | BigNumber; v: number | BigNumber; r: string; s: string },
+    ): ContractTxFunctionObj<
+        [{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }, BigNumber, boolean]
+    > {
+        const self = (this as any) as IZeroExContract;
+
+        const functionSignature =
+            'getLimitOrderRelevantState((address,address,uint128,uint128,uint128,address,address,address,address,bytes32,uint64,uint256),(uint8,uint8,bytes32,bytes32))';
+
+        return {
+            async sendTransactionAsync(
+                txData?: Partial<TxData> | undefined,
+                opts: SendTransactionOpts = { shouldValidate: true },
+            ): Promise<string> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync(
+                    { data: this.getABIEncodedTransactionData(), ...txData },
+                    this.estimateGasAsync.bind(this),
+                );
+                if (opts.shouldValidate !== false) {
+                    await this.callAsync(txDataWithDefaults);
+                }
+                return self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            },
+            awaitTransactionSuccessAsync(
+                txData?: Partial<TxData>,
+                opts: AwaitTransactionSuccessOpts = { shouldValidate: true },
+            ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
+                return self._promiseWithTransactionHash(this.sendTransactionAsync(txData, opts), opts);
+            },
+            async estimateGasAsync(txData?: Partial<TxData> | undefined): Promise<number> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync({
+                    data: this.getABIEncodedTransactionData(),
+                    ...txData,
+                });
+                return self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            },
+            async callAsync(
+                callData: Partial<CallData> = {},
+                defaultBlock?: BlockParam,
+            ): Promise<[{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }, BigNumber, boolean]> {
+                BaseContract._assertCallParams(callData, defaultBlock);
+                const rawCallResult = await self._performCallAsync(
+                    { data: this.getABIEncodedTransactionData(), ...callData },
+                    defaultBlock,
+                );
+                const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
+                return abiEncoder.strictDecodeReturnValue<
+                    [{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }, BigNumber, boolean]
+                >(rawCallResult);
+            },
+            getABIEncodedTransactionData(): string {
+                return self._strictEncodeArguments(functionSignature, [order, signature]);
+            },
+        };
+    }
+    /**
      * Get the block at which a meta-transaction has been executed.
      * @param mtx The meta-transaction.
      */
@@ -4752,6 +5429,81 @@ export class IZeroExContract extends BaseContract {
             },
             getABIEncodedTransactionData(): string {
                 return self._strictEncodeArguments(functionSignature, [order]);
+            },
+        };
+    }
+    /**
+     * Get order info, fillable amount, and signature validity for an RFQ order.
+     * Fillable amount is determined using balances and allowances of the maker.
+     * @param order The RFQ order.
+     * @param signature The order signature.
+     */
+    public getRfqOrderRelevantState(
+        order: {
+            makerToken: string;
+            takerToken: string;
+            makerAmount: BigNumber;
+            takerAmount: BigNumber;
+            maker: string;
+            taker: string;
+            txOrigin: string;
+            pool: string;
+            expiry: BigNumber;
+            salt: BigNumber;
+        },
+        signature: { signatureType: number | BigNumber; v: number | BigNumber; r: string; s: string },
+    ): ContractTxFunctionObj<
+        [{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }, BigNumber, boolean]
+    > {
+        const self = (this as any) as IZeroExContract;
+
+        const functionSignature =
+            'getRfqOrderRelevantState((address,address,uint128,uint128,address,address,address,bytes32,uint64,uint256),(uint8,uint8,bytes32,bytes32))';
+
+        return {
+            async sendTransactionAsync(
+                txData?: Partial<TxData> | undefined,
+                opts: SendTransactionOpts = { shouldValidate: true },
+            ): Promise<string> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync(
+                    { data: this.getABIEncodedTransactionData(), ...txData },
+                    this.estimateGasAsync.bind(this),
+                );
+                if (opts.shouldValidate !== false) {
+                    await this.callAsync(txDataWithDefaults);
+                }
+                return self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            },
+            awaitTransactionSuccessAsync(
+                txData?: Partial<TxData>,
+                opts: AwaitTransactionSuccessOpts = { shouldValidate: true },
+            ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
+                return self._promiseWithTransactionHash(this.sendTransactionAsync(txData, opts), opts);
+            },
+            async estimateGasAsync(txData?: Partial<TxData> | undefined): Promise<number> {
+                const txDataWithDefaults = await self._applyDefaultsToTxDataAsync({
+                    data: this.getABIEncodedTransactionData(),
+                    ...txData,
+                });
+                return self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            },
+            async callAsync(
+                callData: Partial<CallData> = {},
+                defaultBlock?: BlockParam,
+            ): Promise<[{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }, BigNumber, boolean]> {
+                BaseContract._assertCallParams(callData, defaultBlock);
+                const rawCallResult = await self._performCallAsync(
+                    { data: this.getABIEncodedTransactionData(), ...callData },
+                    defaultBlock,
+                );
+                const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
+                return abiEncoder.strictDecodeReturnValue<
+                    [{ orderHash: string; status: number; takerTokenFilledAmount: BigNumber }, BigNumber, boolean]
+                >(rawCallResult);
+            },
+            getABIEncodedTransactionData(): string {
+                return self._strictEncodeArguments(functionSignature, [order, signature]);
             },
         };
     }


### PR DESCRIPTION
## Description

Adds the following `DevUtils`-equivalent functions to `NativeOrdersFeature` in the EP:
- `getLimitOrderRelevantState()`
- `getRfqOrderRelevantState()`
- `batchGetLimitOrderRelevantStates()`
- `batchGetRfqOrderRelevantStates()`

Also updated the return data size checks in `LibERC20TokenV06` to allow for tokens that return >= 32 bytes.

#### TODO
- [x] tests
- [x] Regenerate contract-wrappers

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
