### PR TITLE
fix: CryptoCom rollup

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "0.16.0",
+        "changes": [
+            {
+                "note": "Fix CryptoCom rollup"
+            }
+        ]
+    },
+    {
         "version": "0.15.0",
         "changes": [
             {

--- a/contracts/zero-ex/contracts/src/transformers/bridges/BridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/BridgeAdapter.sol
@@ -95,7 +95,7 @@ contract BridgeAdapter is
         MixinBancor(addresses)
         MixinCoFiX()
         MixinCurve()
-        MixinCryptoCom(addresses)
+        MixinCryptoCom()
         MixinDodo(addresses)
         MixinKyber(addresses)
         MixinMooniswap(addresses)


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Bad constructor initialiser, using the BridgeAddress as the router address :\.

Modified to use the encoded bridgeData which contains the Router address.

```
SELL WETH->WBTC 124.46 -> 3.24 ($78920.14) after NaNs @ prod
	✔ PASS 124.46 -> 3.24 ($77249.28) ($15.04)
	CryptoCom: 100%
	gas: 272873
```

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
