### PR TITLE
fix: [asset-swapper] Encoded Buy fillAmount

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "5.6.1",
+        "changes": [
+            {
+                "note": "Fix fillAmount `ExchangeProxySwapQuoteConsumer` encoding when quote is a BuyQuote"
+            }
+        ]
+    },
+    {
         "version": "5.6.0",
         "changes": [
             {

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -205,7 +205,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                     buyToken,
                     refundReceiver: refundReceiver || NULL_ADDRESS,
                     side: isBuyQuote(quote) ? FillQuoteTransformerSide.Buy : FillQuoteTransformerSide.Sell,
-                    fillAmount: shouldSellEntireBalance ? MAX_UINT256 : fillAmount,
+                    fillAmount: !isBuyQuote(quote) && shouldSellEntireBalance ? MAX_UINT256 : fillAmount,
                     maxOrderFillAmounts: [],
                     rfqtTakerAddress: NULL_ADDRESS,
                     orders: quote.orders,


### PR DESCRIPTION
## Description
Fixes bug where `fillAmount` was being incorrectly encoded with `uint(-1)`. For buys this is problematic as it attempts to perform partial math on the `uint(-1)` amount and results in a `UInt256BinOpError`, even if it it didn't it would revert as it didn't buy `uint(-1)`
<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
