### PR TITLE
fix: Upgrade quote server and Asset Swapper types (and specify protocol ve…

### DIFF
--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -65,7 +65,7 @@
         "@0x/json-schemas": "^5.3.4",
         "@0x/order-utils": "^10.4.13",
         "@0x/orderbook": "0xProject/gitpkg-registry#0x-orderbook-v2.2.7-e10a81023",
-        "@0x/quote-server": "^3.1.0",
+        "@0x/quote-server": "^4.0.1",
         "@0x/types": "^3.3.1",
         "@0x/typescript-typings": "^5.1.6",
         "@0x/utils": "^6.1.1",

--- a/packages/asset-swapper/src/index.ts
+++ b/packages/asset-swapper/src/index.ts
@@ -18,7 +18,7 @@ export {
     SRAPollingOrderProviderOpts,
     SRAWebsocketOrderProviderOpts,
 } from '@0x/orderbook';
-export { RFQTFirmQuote, RFQTIndicativeQuote, TakerRequestQueryParams } from '@0x/quote-server';
+export { V3RFQFirmQuote, V3RFQIndicativeQuote, TakerRequestQueryParams } from '@0x/quote-server';
 export {
     APIOrder,
     Asset,

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -1,4 +1,4 @@
-import { RFQTIndicativeQuote } from '@0x/quote-server';
+import { V3RFQIndicativeQuote } from '@0x/quote-server';
 import { SignedOrder } from '@0x/types';
 import { BigNumber, NULL_ADDRESS } from '@0x/utils';
 import * as _ from 'lodash';
@@ -59,7 +59,7 @@ export async function getRfqtIndicativeQuotesAsync(
     assetFillAmount: BigNumber,
     comparisonPrice: BigNumber | undefined,
     opts: Partial<GetMarketOrdersOpts>,
-): Promise<RFQTIndicativeQuote[]> {
+): Promise<V3RFQIndicativeQuote[]> {
     if (opts.rfqt && opts.rfqt.isIndicative === true && opts.rfqt.quoteRequestor) {
         return opts.rfqt.quoteRequestor.requestRfqtIndicativeQuotesAsync(
             makerAssetData,
@@ -70,7 +70,7 @@ export async function getRfqtIndicativeQuotesAsync(
             opts.rfqt,
         );
     } else {
-        return Promise.resolve<RFQTIndicativeQuote[]>([]);
+        return Promise.resolve<V3RFQIndicativeQuote[]>([]);
     }
 }
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -1,5 +1,5 @@
 import { assetDataUtils, ERC20AssetData, generatePseudoRandomSalt, orderCalculationUtils } from '@0x/order-utils';
-import { RFQTIndicativeQuote } from '@0x/quote-server';
+import { V3RFQIndicativeQuote } from '@0x/quote-server';
 import { SignedOrder } from '@0x/types';
 import { AbiEncoder, BigNumber } from '@0x/utils';
 
@@ -498,7 +498,7 @@ export function createNativeOrder(fill: NativeCollapsedFill): OptimizedMarketOrd
 }
 
 export function createSignedOrdersFromRfqtIndicativeQuotes(
-    quotes: RFQTIndicativeQuote[],
+    quotes: V3RFQIndicativeQuote[],
 ): SignedOrderWithFillableAmounts[] {
     return quotes.map(quote => {
         return {

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -1,4 +1,4 @@
-import { RFQTIndicativeQuote } from '@0x/quote-server';
+import { V3RFQIndicativeQuote } from '@0x/quote-server';
 import { MarketOperation, SignedOrder } from '@0x/types';
 import { BigNumber } from '@0x/utils';
 
@@ -373,7 +373,7 @@ export interface MarketSideLiquidity {
     orderFillableAmounts: BigNumber[];
     ethToOutputRate: BigNumber;
     ethToInputRate: BigNumber;
-    rfqtIndicativeQuotes: RFQTIndicativeQuote[];
+    rfqtIndicativeQuotes: V3RFQIndicativeQuote[];
     twoHopQuotes: Array<DexSample<MultiHopFillData>>;
     quoteSourceFilters: SourceFilters;
     makerTokenDecimals: number;

--- a/packages/asset-swapper/test/quote_requestor_test.ts
+++ b/packages/asset-swapper/test/quote_requestor_test.ts
@@ -42,6 +42,7 @@ describe('QuoteRequestor', async () => {
                 sellAmountBaseUnits: '10000',
                 comparisonPrice: undefined,
                 takerAddress,
+                protocolVersion: '3',
             };
             // Successful response
             const successfulOrder1 = testOrderFactory.generateTestSignedOrder({
@@ -214,6 +215,7 @@ describe('QuoteRequestor', async () => {
                 buyTokenAddress: makerToken,
                 sellAmountBaseUnits: '10000',
                 comparisonPrice: undefined,
+                protocolVersion: '3',
                 takerAddress,
             };
             // Successful response
@@ -313,6 +315,7 @@ describe('QuoteRequestor', async () => {
                 buyTokenAddress: makerToken,
                 buyAmountBaseUnits: '10000',
                 comparisonPrice: undefined,
+                protocolVersion: '3',
                 takerAddress,
             };
             // Successful response

--- a/yarn.lock
+++ b/yarn.lock
@@ -892,12 +892,14 @@
     "@0x/order-utils" "^10.4.2"
     "@0x/utils" "^6.1.0"
 
-"@0x/quote-server@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@0x/quote-server/-/quote-server-3.1.0.tgz#ba5c0de9f88fedfd522ec1ef608dd8eebb868509"
+"@0x/quote-server@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@0x/quote-server/-/quote-server-4.0.1.tgz#05947589bfa7905d274ac3c726cb9918b93b0f9e"
+  integrity sha512-/5yP07a78Fqfj7IKicz57Z1R337iLYQP5qi17lMAmuIjwr7DOoUPMh0HL8FSmrf/Mk79GqC+f3jApTkXyR99fw==
   dependencies:
     "@0x/json-schemas" "^5.0.7"
     "@0x/order-utils" "^10.2.4"
+    "@0x/protocol-utils" "^1.0.1"
     "@0x/utils" "^5.4.1"
     "@types/express" "^4.17.3"
     express "^4.17.1"


### PR DESCRIPTION
- Upgrades Asset Swapper to the latest `@0x/quote-server`
- Updates all types to specify protocol version (in case format changes)
- Passes the `protocolVersion` as an explicit RFQ request parameter