### PR TITLE
EP: Swallow reverts in `batchGetLimit/RfqRelevantStates()`

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "0.18.1",
+        "changes": [
+            {
+                "note": "Swallow reverts in `batchGetLimitOrderRelevantStates()` and `batchGetRfqOrderRelevantStates()`",
+                "pr": 117
+            }
+        ]
+    },
+    {
         "version": "0.18.0",
         "changes": [
             {

--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -387,7 +387,9 @@ interface INativeOrdersFeature {
             bool isSignatureValid
         );
 
-    /// @dev Batch version of `getLimitOrderRelevantState()`.
+    /// @dev Batch version of `getLimitOrderRelevantState()`, without reverting.
+    ///      Orders that would normally cause `getLimitOrderRelevantState()`
+    ///      to revert will have empty results.
     /// @param orders The limit orders.
     /// @param signatures The order signatures.
     /// @return orderInfos Info about the orders.
@@ -406,7 +408,9 @@ interface INativeOrdersFeature {
             bool[] memory isSignatureValids
         );
 
-    /// @dev Batch version of `getRfqOrderRelevantState()`.
+    /// @dev Batch version of `getRfqOrderRelevantState()`, without reverting.
+    ///      Orders that would normally cause `getLimitOrderRelevantState()`
+    ///      to revert will have empty results.
     /// @param orders The RFQ orders.
     /// @param signatures The order signatures.
     /// @return orderInfos Info about the orders.

--- a/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/INativeOrdersFeature.sol
@@ -409,7 +409,7 @@ interface INativeOrdersFeature {
         );
 
     /// @dev Batch version of `getRfqOrderRelevantState()`, without reverting.
-    ///      Orders that would normally cause `getLimitOrderRelevantState()`
+    ///      Orders that would normally cause `getRfqOrderRelevantState()`
     ///      to revert will have empty results.
     /// @param orders The RFQ orders.
     /// @param signatures The order signatures.

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -819,7 +819,7 @@ contract NativeOrdersFeature is
     }
 
     /// @dev Batch version of `getRfqOrderRelevantState()`, without reverting.
-    ///      Orders that would normally cause `getLimitOrderRelevantState()`
+    ///      Orders that would normally cause `getRfqOrderRelevantState()`
     ///      to revert will have empty results.
     /// @param orders The RFQ orders.
     /// @param signatures The order signatures.

--- a/contracts/zero-ex/contracts/src/features/libs/LibNativeOrder.sol
+++ b/contracts/zero-ex/contracts/src/features/libs/LibNativeOrder.sol
@@ -103,8 +103,8 @@ library LibNativeOrder {
     //       "uint128 makerAmount,",
     //       "uint128 takerAmount,",
     //       "address maker,",
-    //       "address txOrigin,",
     //       "address taker,",
+    //       "address txOrigin,",
     //       "bytes32 pool,",
     //       "uint64 expiry,",
     //       "uint256 salt"


### PR DESCRIPTION
## Description

`getXOrderRelevantState()` can revert for a number of reasons (math ops, invalid tokens, etc), and therefore so do the batch versions. Mesh needs a batch function that is hardier.

This amends `batchGetLimitOrderRelevantState()` and `batchGetLimitOrderRelevantState()` to use `try this... catch` semantics to swallow reverts and return empty results for failing orders.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
