### PR TITLE
`@0x/protocol-utils`: Use `Web3Wrapper.signTypedDataAsync()`

### DIFF
--- a/packages/protocol-utils/CHANGELOG.json
+++ b/packages/protocol-utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "1.1.5",
+        "changes": [
+            {
+                "note": "Use `Web3Wrapper.signTypedDataAsync()` instead of removed `Web3Wrapper.signTypedDataV4Async()`",
+                "pr": 124
+            }
+        ]
+    },
+    {
         "timestamp": 1610510890,
         "version": "1.1.4",
         "changes": [

--- a/packages/protocol-utils/src/signature_utils.ts
+++ b/packages/protocol-utils/src/signature_utils.ts
@@ -68,7 +68,7 @@ export async function eip712SignTypedDataWithProviderAsync(
     provider: SupportedProvider,
 ): Promise<Signature> {
     const w3w = new Web3Wrapper(providerUtils.standardizeOrThrow(provider));
-    const rpcSig = await w3w.signTypedDataV4Async(signer, data);
+    const rpcSig = await w3w.signTypedDataAsync(signer, data);
     return {
         ...parseRpcSignature(rpcSig),
         signatureType: SignatureType.EIP712,


### PR DESCRIPTION
## Description

Because `Web3Wrapper.signTypedDataV4Async()` will be removed by https://github.com/0xProject/tools/pull/21

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
