### PR TITLE
Make the proposal/quorum thresholds updatable

### DIFF
--- a/contracts/treasury/CHANGELOG.json
+++ b/contracts/treasury/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "1.1.0",
+        "changes": [
+            {
+                "note": "Make the proposal/quorum thresholds updatable",
+                "pr": 165
+            }
+        ]
+    },
+    {
         "timestamp": 1614141718,
         "version": "1.0.2",
         "changes": [

--- a/contracts/treasury/contracts/src/IZrxTreasury.sol
+++ b/contracts/treasury/contracts/src/IZrxTreasury.sol
@@ -96,6 +96,18 @@ interface IZrxTreasury {
         view
         returns (uint256);
 
+    /// @dev Updates the proposal and quorum thresholds to the given
+    ///      values. Note that this function is only callable by the
+    ///      treasury contract itself, so the threshold can only be
+    ///      updated via a successful treasury proposal.
+    /// @param newProposalThreshold The new value for the proposal threshold.
+    /// @param newQuorumThreshold The new value for the quorum threshold.
+    function updateThresholds(
+        uint256 newProposalThreshold,
+        uint256 newQuorumThreshold
+    )
+        external;
+
     /// @dev Creates a proposal to send ZRX from this treasury on the
     ///      the given actions. Must have at least `proposalThreshold`
     ///      of voting power to call this function. See `getVotingPower`

--- a/contracts/treasury/contracts/src/ZrxTreasury.sol
+++ b/contracts/treasury/contracts/src/ZrxTreasury.sol
@@ -42,8 +42,8 @@ contract ZrxTreasury is
     DefaultPoolOperator public immutable override defaultPoolOperator;
     bytes32 public immutable override defaultPoolId;
     uint256 public immutable override votingPeriod;
-    uint256 public immutable override proposalThreshold;
-    uint256 public immutable override quorumThreshold;
+    uint256 public override proposalThreshold;
+    uint256 public override quorumThreshold;
 
     // Storage
     Proposal[] public proposals;
@@ -81,6 +81,24 @@ contract ZrxTreasury is
     /// @dev Allows this contract to receive ether.
     receive() external payable {}
     // solhint-enable
+
+    /// @dev Updates the proposal and quorum thresholds to the given
+    ///      values. Note that this function is only callable by the
+    ///      treasury contract itself, so the threshold can only be
+    ///      updated via a successful treasury proposal.
+    /// @param newProposalThreshold The new value for the proposal threshold.
+    /// @param newQuorumThreshold The new value for the quorum threshold.
+    function updateThresholds(
+        uint256 newProposalThreshold,
+        uint256 newQuorumThreshold
+    )
+        external
+        override
+    {
+        require(msg.sender == address(this), "updateThresholds/ONLY_SELF");
+        proposalThreshold = newProposalThreshold;
+        quorumThreshold = newQuorumThreshold;
+    }
 
     /// @dev Creates a proposal to send ZRX from this treasury on the
     ///      the given actions. Must have at least `proposalThreshold`


### PR DESCRIPTION
## Description
Changes `proposalThreshold` and `quorumThreshold` from immutables to state variables than can be updated via the new `updateThresholds` function. The `updateThresholds` function can only be called by the Treasury itself, so an update would need to be encoded in a proposal. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
