### PR TITLE
feat: Prune Paths + Fast ABI

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -7,7 +7,7 @@
                 "pr": 183
             },
             {
-                "note": "Disable ABI encode optimization for the Sampler contract",
+                "note": "Use FastABI for Sampler ABI encoding and decoding",
                 "pr": 183
             }
         ]

--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.8.0",
+        "changes": [
+            {
+                "note": "Prune paths which cannot improve the best path",
+                "pr": 183
+            }
+        ]
+    },
+    {
         "version": "6.7.0",
         "changes": [
             {

--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Prune paths which cannot improve the best path",
                 "pr": 183
+            },
+            {
+                "note": "Disable ABI encode optimization for the Sampler contract",
+                "pr": 183
             }
         ]
     },

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -58,7 +58,7 @@
     },
     "dependencies": {
         "@0x/assert": "^3.0.26",
-        "@0x/base-contract": "^6.3.2",
+        "@0x/base-contract": "^6.4.0",
         "@0x/contract-addresses": "^6.0.0",
         "@0x/contract-wrappers": "^13.15.0",
         "@0x/contracts-erc20": "^3.3.6",
@@ -90,7 +90,6 @@
     },
     "devDependencies": {
         "@0x/abi-gen": "^5.5.0",
-        "@0x/base-contract": "^6.3.2",
         "@0x/contracts-asset-proxy": "^3.7.9",
         "@0x/contracts-exchange": "^3.2.28",
         "@0x/contracts-exchange-libs": "^4.3.27",

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -88,6 +88,7 @@
         "lodash": "^4.17.11"
     },
     "devDependencies": {
+        "@0x/abi-gen": "^5.5.0",
         "@0x/base-contract": "^6.3.2",
         "@0x/contracts-asset-proxy": "^3.7.9",
         "@0x/contracts-exchange": "^3.2.28",

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -84,7 +84,7 @@
         "decimal.js": "^10.2.0",
         "ethereum-types": "^3.5.0",
         "ethereumjs-util": "^7.0.10",
-        "fast-abi": "^0.0.1",
+        "fast-abi": "^0.0.2",
         "heartbeats": "^5.0.1",
         "lodash": "^4.17.11"
     },

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -89,7 +89,7 @@
         "lodash": "^4.17.11"
     },
     "devDependencies": {
-        "@0x/abi-gen": "^5.5.0",
+        "@0x/abi-gen": "^5.6.0",
         "@0x/contracts-asset-proxy": "^3.7.9",
         "@0x/contracts-exchange": "^3.2.28",
         "@0x/contracts-exchange-libs": "^4.3.27",

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -84,6 +84,7 @@
         "decimal.js": "^10.2.0",
         "ethereum-types": "^3.5.0",
         "ethereumjs-util": "^7.0.10",
+        "fast-abi": "^0.0.1",
         "heartbeats": "^5.0.1",
         "lodash": "^4.17.11"
     },

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -1,4 +1,3 @@
-import { EncoderOverrides } from '@0x/base-contract';
 import { ChainId, getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
 import { FillQuoteTransformerOrderType, LimitOrder } from '@0x/protocol-utils';
 import { BigNumber, providerUtils } from '@0x/utils';

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -128,6 +128,9 @@ export class SwapQuoter {
             {
                 gas: samplerGasLimit,
             },
+            {},
+            undefined,
+            { shouldOptimize: false, shouldAnnotate: false },
         );
 
         this._marketOperationUtils = new MarketOperationUtils(

--- a/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
@@ -1025,7 +1025,7 @@ export const DEFAULT_GAS_SCHEDULE: Required<FeeSchedule> = {
     },
     [ERC20BridgeSource.Uniswap]: () => 90e3,
     [ERC20BridgeSource.LiquidityProvider]: fillData => {
-        return (fillData as LiquidityProviderFillData).gasCost;
+        return (fillData as LiquidityProviderFillData).gasCost || 100e3;
     },
     [ERC20BridgeSource.Eth2Dai]: () => 400e3,
     [ERC20BridgeSource.Kyber]: () => 450e3,

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -152,7 +152,7 @@ function dexSamplesToFills(
         const { source, fillData } = sample;
         const input = sample.input.minus(prevSample ? prevSample.input : 0);
         const output = sample.output.minus(prevSample ? prevSample.output : 0);
-        const fee = fees[source] === undefined ? 0 : fees[source]!(sample.fillData);
+        const fee = fees[source] === undefined ? 0 : fees[source]!(sample.fillData) || 0;
         let penalty = ZERO_AMOUNT;
         if (i === 0) {
             // Only the first fill in a DEX path incurs a penalty.

--- a/packages/asset-swapper/src/utils/market_operation_utils/path.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path.ts
@@ -39,7 +39,6 @@ export class Path {
     public sourceFlags: number = 0;
     protected _size: PathSize = { input: ZERO_AMOUNT, output: ZERO_AMOUNT };
     protected _adjustedSize: PathSize = { input: ZERO_AMOUNT, output: ZERO_AMOUNT };
-    private readonly _bestFill?: Fill;
 
     public static create(
         side: MarketOperation,

--- a/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
@@ -141,6 +141,13 @@ export class SamplerOperations {
         orders: SignedNativeOrder[],
         exchangeAddress: string,
     ): BatchedOperation<BigNumber[]> {
+        // Skip checking empty or invalid orders on-chain, returning a constant
+        if (orders.length === 0) {
+            return SamplerOperations.constant<BigNumber[]>([]);
+        }
+        if (orders.length === 1 && orders[0].order.maker === NULL_ADDRESS) {
+            return SamplerOperations.constant<BigNumber[]>([ZERO_AMOUNT]);
+        }
         return new SamplerContractOperation({
             source: ERC20BridgeSource.Native,
             contract: this._samplerContract,
@@ -154,6 +161,13 @@ export class SamplerOperations {
         orders: SignedNativeOrder[],
         exchangeAddress: string,
     ): BatchedOperation<BigNumber[]> {
+        // Skip checking empty or invalid orders on-chain, returning a constant
+        if (orders.length === 0) {
+            return SamplerOperations.constant<BigNumber[]>([]);
+        }
+        if (orders.length === 1 && orders[0].order.maker === NULL_ADDRESS) {
+            return SamplerOperations.constant<BigNumber[]>([ZERO_AMOUNT]);
+        }
         return new SamplerContractOperation({
             source: ERC20BridgeSource.Native,
             contract: this._samplerContract,

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -299,6 +299,7 @@ describe('MarketOperationUtils tests', () => {
         [ERC20BridgeSource.Native]: createDecreasingRates(NUM_SAMPLES),
         [ERC20BridgeSource.Eth2Dai]: createDecreasingRates(NUM_SAMPLES),
         [ERC20BridgeSource.Uniswap]: createDecreasingRates(NUM_SAMPLES),
+        [ERC20BridgeSource.Kyber]: createDecreasingRates(NUM_SAMPLES),
     };
 
     interface FillDataBySource {

--- a/packages/contract-wrappers/src/generated-wrappers/broker.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/broker.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -528,6 +529,9 @@ export class BrokerContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as BrokerContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -914,7 +918,7 @@ export class BrokerContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = BrokerContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'Broker',
@@ -924,7 +928,7 @@ export class BrokerContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         BrokerContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/coordinator.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -552,6 +553,9 @@ export class CoordinatorContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as CoordinatorContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -966,7 +970,7 @@ export class CoordinatorContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = CoordinatorContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'Coordinator',
@@ -976,7 +980,7 @@ export class CoordinatorContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         CoordinatorContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/dev_utils.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/dev_utils.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -1569,6 +1570,9 @@ export class DevUtilsContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as DevUtilsContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -3371,7 +3375,7 @@ export class DevUtilsContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = DevUtilsContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'DevUtils',
@@ -3381,7 +3385,7 @@ export class DevUtilsContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         DevUtilsContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/erc20_token.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -400,6 +401,9 @@ export class ERC20TokenContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as ERC20TokenContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -759,7 +763,7 @@ export class ERC20TokenContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ERC20TokenContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'ERC20Token',
@@ -769,7 +773,7 @@ export class ERC20TokenContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ERC20TokenEventArgs, ERC20TokenEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/erc721_token.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -490,6 +491,9 @@ export class ERC721TokenContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as ERC721TokenContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -1039,7 +1043,7 @@ export class ERC721TokenContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ERC721TokenContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'ERC721Token',
@@ -1049,7 +1053,7 @@ export class ERC721TokenContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ERC721TokenEventArgs, ERC721TokenEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/exchange.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -3200,6 +3201,9 @@ export class ExchangeContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as ExchangeContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -6261,7 +6265,7 @@ export class ExchangeContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ExchangeContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'Exchange',
@@ -6271,7 +6275,7 @@ export class ExchangeContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ExchangeEventArgs, ExchangeEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/forwarder.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -752,6 +753,9 @@ export class ForwarderContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as ForwarderContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -1589,7 +1593,7 @@ export class ForwarderContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ForwarderContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'Forwarder',
@@ -1599,7 +1603,7 @@ export class ForwarderContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ForwarderEventArgs, ForwarderEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/gods_unchained_validator.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/gods_unchained_validator.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -254,6 +255,9 @@ export class GodsUnchainedValidatorContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as GodsUnchainedValidatorContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -304,7 +308,7 @@ export class GodsUnchainedValidatorContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = GodsUnchainedValidatorContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'GodsUnchainedValidator',
@@ -314,7 +318,7 @@ export class GodsUnchainedValidatorContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         GodsUnchainedValidatorContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/i_asset_data.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_asset_data.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -323,6 +324,9 @@ export class IAssetDataContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as IAssetDataContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -758,7 +762,7 @@ export class IAssetDataContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = IAssetDataContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'IAssetData',
@@ -768,7 +772,7 @@ export class IAssetDataContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         IAssetDataContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/i_liquidity_provider.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_liquidity_provider.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -304,6 +305,9 @@ export class ILiquidityProviderContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as ILiquidityProviderContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -477,7 +481,7 @@ export class ILiquidityProviderContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ILiquidityProviderContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'ILiquidityProvider',
@@ -487,7 +491,7 @@ export class ILiquidityProviderContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         ILiquidityProviderContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/i_transform_erc20.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_transform_erc20.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -468,6 +469,9 @@ export class ITransformERC20Contract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as ITransformERC20Contract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -1082,7 +1086,7 @@ export class ITransformERC20Contract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ITransformERC20Contract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'ITransformERC20',
@@ -1092,7 +1096,7 @@ export class ITransformERC20Contract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ITransformERC20EventArgs, ITransformERC20Events>(

--- a/packages/contract-wrappers/src/generated-wrappers/i_zero_ex.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_zero_ex.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -3358,6 +3359,9 @@ export class IZeroExContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as IZeroExContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -7338,7 +7342,7 @@ export class IZeroExContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = IZeroExContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'IZeroEx',
@@ -7348,7 +7352,7 @@ export class IZeroExContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<IZeroExEventArgs, IZeroExEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/maximum_gas_price.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/maximum_gas_price.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -226,6 +227,9 @@ export class MaximumGasPriceContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as MaximumGasPriceContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -298,7 +302,7 @@ export class MaximumGasPriceContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = MaximumGasPriceContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'MaximumGasPrice',
@@ -308,7 +312,7 @@ export class MaximumGasPriceContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         MaximumGasPriceContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/staking.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/staking.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -1669,6 +1670,9 @@ export class StakingContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as StakingContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -3731,7 +3735,7 @@ export class StakingContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = StakingContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'Staking',
@@ -3741,7 +3745,7 @@ export class StakingContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<StakingEventArgs, StakingEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/staking_proxy.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/staking_proxy.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -796,6 +797,9 @@ export class StakingProxyContract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as StakingProxyContract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -1745,7 +1749,7 @@ export class StakingProxyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = StakingProxyContract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'StakingProxy',
@@ -1755,7 +1759,7 @@ export class StakingProxyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<StakingProxyEventArgs, StakingProxyEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/weth9.ts
@@ -3,6 +3,7 @@
 // tslint:disable:no-unused-variable
 import {
     AwaitTransactionSuccessOpts,
+    EncoderOverrides,
     ContractFunctionObj,
     ContractTxFunctionObj,
     SendTransactionOpts,
@@ -524,6 +525,9 @@ export class WETH9Contract extends BaseContract {
     }
 
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
+        if (this._encoderOverrides.decodeOutput) {
+            return this._encoderOverrides.decodeOutput(methodName, callData);
+        }
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as WETH9Contract;
         const abiEncoder = self._lookupAbiEncoder(functionSignature);
@@ -1028,7 +1032,7 @@ export class WETH9Contract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = WETH9Contract.deployedBytecode,
-        encodingRules?: EncodingRules,
+        encoderOverrides?: Partial<EncoderOverrides>,
     ) {
         super(
             'WETH9',
@@ -1038,7 +1042,7 @@ export class WETH9Contract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
-            encodingRules,
+            encoderOverrides,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<WETH9EventArgs, WETH9Events>(

--- a/packages/contract-wrappers/src/index.ts
+++ b/packages/contract-wrappers/src/index.ts
@@ -3,6 +3,7 @@ export {
     ContractEvent,
     ContractFunctionObj,
     ContractTxFunctionObj,
+    EncoderOverrides,
     SendTransactionOpts,
     SubscriptionErrors,
 } from '@0x/base-contract';

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,6 +666,28 @@
     toposort "^2.0.2"
     yargs "^10.0.3"
 
+"@0x/abi-gen@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.5.0.tgz#21d15b79e0d8e3377e8b06ce440fea0528d8f021"
+  dependencies:
+    "@0x/types" "^3.3.3"
+    "@0x/typescript-typings" "^5.2.0"
+    "@0x/utils" "^6.4.0"
+    "@types/node" "12.12.54"
+    "@types/toposort" "^2.0.1"
+    chalk "^2.3.0"
+    change-case "^3.0.2"
+    cli-format "^3.0.9"
+    ethereum-types "^3.5.0"
+    glob "^7.1.2"
+    handlebars "^4.1.2"
+    lodash "^4.17.11"
+    mkdirp "^0.5.1"
+    tmp "^0.0.33"
+    to-snake-case "^1.0.0"
+    toposort "^2.0.2"
+    yargs "^10.0.3"
+
 "@0x/assert@^3.0.1", "@0x/assert@^3.0.17":
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.17.tgz#dc15d038ed085744cb375044218285368f0cbfa8"
@@ -700,10 +722,20 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/asset-swapper@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@0x/asset-swapper/-/asset-swapper-6.7.0.tgz#c57747cd8fc2de853ddd75592b98ca0c4ba5bd2d"
-  integrity sha512-CJeQohcb493MgO39BpnXWMYnhnvA2r8Q711Nso6VHQDi/wKSAnn5UqJXyq7CxGzS2qyyagUBX3xeuNfM+EkxbQ==
+"@0x/assert@^3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.24.tgz#e1153b0c156ed8f7caec6b221f9d7a5997bdcae1"
+  dependencies:
+    "@0x/json-schemas" "^6.1.0"
+    "@0x/typescript-typings" "^5.2.0"
+    "@0x/utils" "^6.4.0"
+    "@types/node" "12.12.54"
+    lodash "^4.17.11"
+    valid-url "^1.0.9"
+
+"@0x/base-contract@^6.2.18":
+  version "6.2.18"
+  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.2.18.tgz#d092de93d52d8cf8e5d4600d9ca852421322ab38"
   dependencies:
     "@0x/assert" "^3.0.21"
     "@0x/base-contract" "^6.2.18"
@@ -744,6 +776,23 @@
     "@0x/json-schemas" "^6.1.2"
     "@0x/utils" "^6.4.2"
     "@0x/web3-wrapper" "^7.5.2"
+    "@types/node" "12.12.54"
+    ethereumjs-account "^3.0.0"
+    ethereumjs-blockstream "^7.0.0"
+    ethereumjs-util "^7.0.10"
+    ethereumjs-vm "^4.2.0"
+    ethers "~4.0.4"
+    js-sha3 "^0.7.0"
+    uuid "^3.3.2"
+
+"@0x/base-contract@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.3.0.tgz#dfa9205761580e5b5f4c3db8f74ecaa7606b58af"
+  dependencies:
+    "@0x/assert" "^3.0.24"
+    "@0x/json-schemas" "^6.1.0"
+    "@0x/utils" "^6.4.0"
+    "@0x/web3-wrapper" "^7.5.0"
     "@types/node" "12.12.54"
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
@@ -854,10 +903,9 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0x/json-schemas@^6.1.2":
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.2.tgz#e25c8ba453128a529bb95973a631714ec9127356"
-  integrity sha512-sjoVBVhpsPKR/hKoXw/P/YwB7pIm3KpDd7piBiPbTrRlNeE6NKClR+/nGMkpGYiY8rMm3pklxx4wvsLOB4g7og==
+"@0x/json-schemas@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.0.tgz#5b238bc4e3da06638534e5e5f53ab89a41913a71"
   dependencies:
     "@0x/typescript-typings" "^5.2.0"
     "@types/node" "12.12.54"
@@ -957,7 +1005,6 @@
 "@0x/quote-server@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@0x/quote-server/-/quote-server-5.0.0.tgz#15554099bdfdf71e2910430860257d622f24f703"
-  integrity sha512-U14C60RVnILL8n5DwuInG98MnhXbBbiEi8M2ymFGnHO+AjucGfm28BM6/GD59ftiqZmFSkOvBRU94QJ3mSsCQw==
   dependencies:
     "@0x/json-schemas" "^5.0.7"
     "@0x/order-utils" "^10.2.4"
@@ -1183,7 +1230,6 @@
 "@0x/types@^3.3.3":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@0x/types/-/types-3.3.3.tgz#5df4ec381bba9f62441474b0e54309ddb2fccd17"
-  integrity sha512-pImq1ukZl+YN64ZKQqNPTOK8noNw4rHMksEEPzFGM26x7Utovf8Py+VFqbZrn1TMw/9WWGeZg8lPxs+LUYxayw==
   dependencies:
     "@types/node" "12.12.54"
     bignumber.js "~9.0.0"
@@ -1214,7 +1260,6 @@
 "@0x/typescript-typings@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@0x/typescript-typings/-/typescript-typings-5.2.0.tgz#3eba353a27a83697f6f4f6d65ce14506687f52b7"
-  integrity sha512-8Gk0riQ37HTv3bNe/iWsb9mcJuRCMk/16PZTzA3IUauNQajcJgTD601pHbmBF57SJDpFhJIRg2Crcf6hePlzBA==
   dependencies:
     "@types/bn.js" "^4.11.0"
     "@types/node" "12.12.54"
@@ -1277,10 +1322,9 @@
     js-sha3 "^0.7.0"
     lodash "^4.17.11"
 
-"@0x/utils@^6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.2.tgz#b5d86854383bfe4a3fccdcb8e70aad2efde58250"
-  integrity sha512-dcWhhySAa8rZ7AGlu4ETacEPkXEsj6Rg8qMWJX69SNwjb3ZHsuEIVzt8KsFKLTGgx9sgzqyF+qqlKD2oFFiqiw==
+"@0x/utils@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.0.tgz#942505ae628e00ba865ecf65885f3cecc293fde9"
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/typescript-typings" "^5.2.0"
@@ -1320,6 +1364,20 @@
     "@0x/json-schemas" "^6.1.2"
     "@0x/typescript-typings" "^5.2.0"
     "@0x/utils" "^6.4.2"
+    "@types/node" "12.12.54"
+    ethereum-types "^3.5.0"
+    ethereumjs-util "^7.0.10"
+    ethers "~4.0.4"
+    lodash "^4.17.11"
+
+"@0x/web3-wrapper@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.0.tgz#e33a4400fb511389b2e67e6ffb9df290f6842ec4"
+  dependencies:
+    "@0x/assert" "^3.0.24"
+    "@0x/json-schemas" "^6.1.0"
+    "@0x/typescript-typings" "^5.2.0"
+    "@0x/utils" "^6.4.0"
     "@types/node" "12.12.54"
     ethereum-types "^3.5.0"
     ethereumjs-util "^7.0.10"
@@ -2618,7 +2676,6 @@
 "@types/bn.js@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
-  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
   dependencies:
     "@types/node" "*"
 
@@ -5940,7 +5997,6 @@ ethereum-types@^3.4.0:
 ethereum-types@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/ethereum-types/-/ethereum-types-3.5.0.tgz#27393f0d86f55bb1dcbff8a6af55a39c1f751c0d"
-  integrity sha512-vTGJl45DxOK21w3rzlqV8KrfcdIJC+4ZqxFkjNf1aw2GBMXZy2MxiibUqBth2M823d98WgOuFpVHobOfa7ejDw==
   dependencies:
     "@types/node" "12.12.54"
     bignumber.js "~9.0.0"
@@ -6086,10 +6142,9 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.9:
+ethereumjs-util@^7.0.10:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
-  integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
   dependencies:
     "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"
@@ -12605,7 +12660,6 @@ typescript@3.7.x:
 typescript@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 typescript@^3.8.3:
   version "3.9.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,29 +643,7 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@0x/abi-gen@^5.4.21":
-  version "5.4.21"
-  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.4.21.tgz#96705962c75e116bd5050784287012ede4607564"
-  dependencies:
-    "@0x/types" "^3.3.1"
-    "@0x/typescript-typings" "^5.1.6"
-    "@0x/utils" "^6.2.0"
-    "@types/node" "12.12.54"
-    "@types/toposort" "^2.0.1"
-    chalk "^2.3.0"
-    change-case "^3.0.2"
-    cli-format "^3.0.9"
-    ethereum-types "^3.4.0"
-    glob "^7.1.2"
-    handlebars "^4.1.2"
-    lodash "^4.17.11"
-    mkdirp "^0.5.1"
-    tmp "^0.0.33"
-    to-snake-case "^1.0.0"
-    toposort "^2.0.2"
-    yargs "^10.0.3"
-
-"@0x/abi-gen@^5.6.0":
+"@0x/abi-gen@^5.5.0", "@0x/abi-gen@^5.5.2":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.6.0.tgz#2b022efe77a35f5589624633d880d794d0a16bde"
   dependencies:
@@ -698,25 +676,13 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/assert@^3.0.21", "@0x/assert@^3.0.26":
+"@0x/assert@^3.0.26":
   version "3.0.26"
   resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.26.tgz#c9c3209e093c5fcbb5ff8d3b8f767d35c87195fc"
-  integrity sha512-CR7Y7yaj5C05Z1UCPesYp6yjf7/e9FEZUqzXi2eX6iUCsG2SMV5w7wG99jOW9wgtbgVGP3rpG6NT6TUfL5zRVg==
   dependencies:
     "@0x/json-schemas" "^6.1.2"
     "@0x/typescript-typings" "^5.2.0"
     "@0x/utils" "^6.4.2"
-    "@types/node" "12.12.54"
-    lodash "^4.17.11"
-    valid-url "^1.0.9"
-
-"@0x/assert@^3.0.6":
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.21.tgz#b385868d1833625912fd9173a2477be5a4090aed"
-  dependencies:
-    "@0x/json-schemas" "^5.4.1"
-    "@0x/typescript-typings" "^5.1.6"
-    "@0x/utils" "^6.2.0"
     "@types/node" "12.12.54"
     lodash "^4.17.11"
     valid-url "^1.0.9"
@@ -732,24 +698,18 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/base-contract@^6.2.18":
-  version "6.2.18"
-  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.2.18.tgz#d092de93d52d8cf8e5d4600d9ca852421322ab38"
+"@0x/assert@^3.0.6":
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.21.tgz#b385868d1833625912fd9173a2477be5a4090aed"
   dependencies:
-    "@0x/assert" "^3.0.21"
     "@0x/json-schemas" "^5.4.1"
+    "@0x/typescript-typings" "^5.1.6"
     "@0x/utils" "^6.2.0"
-    "@0x/web3-wrapper" "^7.4.1"
     "@types/node" "12.12.54"
-    ethereumjs-account "^3.0.0"
-    ethereumjs-blockstream "^7.0.0"
-    ethereumjs-util "^5.1.1"
-    ethereumjs-vm "^4.2.0"
-    ethers "~4.0.4"
-    js-sha3 "^0.7.0"
-    uuid "^3.3.2"
+    lodash "^4.17.11"
+    valid-url "^1.0.9"
 
-"@0x/base-contract@^6.4.0":
+"@0x/base-contract@^6.3.2", "@0x/base-contract@^6.4.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.4.0.tgz#7ffcb18b0b8d522545074cada1f4d62dce0a88ec"
   dependencies:
@@ -773,7 +733,6 @@
 "@0x/contracts-gen@^2.0.37":
   version "2.0.37"
   resolved "https://registry.yarnpkg.com/@0x/contracts-gen/-/contracts-gen-2.0.37.tgz#5b15a8921355c4a2fc74609661246e1d707283d0"
-  integrity sha512-CWqJwGuPjSWx2H2hXfc5KreMcz7bz+s9NrK8riBBtF9kZbYsYEunuDQ2Du5Q5StzCiO4rQT42hdA3U3+nReKug==
   dependencies:
     "@0x/sol-compiler" "^4.7.2"
     "@0x/sol-resolver" "^3.1.8"
@@ -786,21 +745,6 @@
     mkdirp "^0.5.1"
     prettier "^1.16.3"
     to-snake-case "^1.0.0"
-
-"@0x/contracts-zero-ex@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@0x/contracts-zero-ex/-/contracts-zero-ex-0.22.0.tgz#680c0837ffc7a36dd7358f9d2713d34431269b53"
-  integrity sha512-F0DtG9SFY3g9c2uX7Airekg20dNiT5fHc7y/4XZ2blG5OS+IDlcEmM+ZQPjyXiJPzfqJKzEeKsNQw+LwcJobxQ==
-  dependencies:
-    "@0x/base-contract" "^6.2.18"
-    "@0x/protocol-utils" "^1.5.0"
-    "@0x/subproviders" "^6.4.1"
-    "@0x/types" "^3.3.1"
-    "@0x/typescript-typings" "^5.1.6"
-    "@0x/utils" "^6.2.0"
-    "@0x/web3-wrapper" "^7.4.1"
-    ethereum-types "^3.4.0"
-    ethereumjs-util "^5.1.1"
 
 "@0x/coordinator-server@^1.0.5":
   version "1.0.5"
@@ -829,10 +773,9 @@
     typeorm "0.2.7"
     websocket "^1.0.25"
 
-"@0x/dev-utils@^4.2.1", "@0x/dev-utils@^4.2.6":
+"@0x/dev-utils@^4.2.6":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@0x/dev-utils/-/dev-utils-4.2.6.tgz#7e918d045c4aeb10aa9ce922c8315a1953b40888"
-  integrity sha512-JvqWNoGVye9y37eMo+0izaPVzbwBov90w0DNJ/Ek58Mi67XGWqRdHnIG3EEeQzwHrsaSmdBuye9UPXLDBMaSpQ==
   dependencies:
     "@0x/subproviders" "^6.5.2"
     "@0x/types" "^3.3.3"
@@ -867,7 +810,7 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0x/json-schemas@^6.1.3":
+"@0x/json-schemas@^6.1.2", "@0x/json-schemas@^6.1.3":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.3.tgz#da71ed2e50ae6813a6d4d0fe5f8ad69b8e6a7435"
   dependencies:
@@ -888,43 +831,9 @@
     web3-providers "^2.0.0-alpha.1"
     websocket "^1.0.29"
 
-"@0x/migrations@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@0x/migrations/-/migrations-8.0.2.tgz#f37a53e086b1db5e75eb6e455d9e57d4d3fc9fbb"
-  integrity sha512-UPK3GQ3z/hmeVXiaglj00d3bYeXRqtq2i6lFP4J2JAIxtEBuPFbTpUX/4stiPkGHZXAtM3v6Q6lz/qiNNN8hFQ==
-  dependencies:
-    "@0x/base-contract" "^6.2.18"
-    "@0x/contract-addresses" "^6.0.0"
-    "@0x/contracts-asset-proxy" "^3.7.9"
-    "@0x/contracts-coordinator" "^3.1.28"
-    "@0x/contracts-dev-utils" "^1.3.26"
-    "@0x/contracts-erc1155" "^2.1.27"
-    "@0x/contracts-erc20" "^3.3.6"
-    "@0x/contracts-erc721" "^3.1.27"
-    "@0x/contracts-exchange" "^3.2.28"
-    "@0x/contracts-exchange-forwarder" "^4.2.28"
-    "@0x/contracts-extensions" "^6.2.22"
-    "@0x/contracts-multisig" "^4.1.28"
-    "@0x/contracts-staking" "^2.0.35"
-    "@0x/contracts-utils" "^4.7.6"
-    "@0x/contracts-zero-ex" "^0.22.0"
-    "@0x/sol-compiler" "^4.6.1"
-    "@0x/subproviders" "^6.4.1"
-    "@0x/typescript-typings" "^5.1.6"
-    "@0x/utils" "^6.2.0"
-    "@0x/web3-wrapper" "^7.4.1"
-    "@ledgerhq/hw-app-eth" "^4.3.0"
-    "@types/web3-provider-engine" "^14.0.0"
-    ethereum-types "^3.4.0"
-    ethers "~4.0.4"
-    lodash "^4.17.11"
-  optionalDependencies:
-    "@ledgerhq/hw-transport-node-hid" "^4.3.0"
-
 "@0x/monorepo-scripts@^3.1.6":
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/@0x/monorepo-scripts/-/monorepo-scripts-3.1.6.tgz#a33a8e1706f5d6ce7277a15b48ade48b3ec2cf9a"
-  integrity sha512-QDGTx5mbdGBMyw+b4/sL9OmXea+UJlkhbeKuKtEdvwAu43guAyrB63jP0yFIhMoiD8exD67yaGol1qA75qBVpA==
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/utils" "^6.4.2"
@@ -949,23 +858,6 @@
     typedoc "~0.16.11"
     yargs "^10.0.3"
 
-"@0x/protocol-utils@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@0x/protocol-utils/-/protocol-utils-1.5.0.tgz#2e479a5ecde2801a756d81dc017eece51116decf"
-  integrity sha512-/5pIK9ssJXx2VyZPW2zKVkNNEAZLgGHDFmuX9MzjAG7DXi4cknbYkepguFgebhKtsksvWokSEk9V8I/a608Vtg==
-  dependencies:
-    "@0x/assert" "^3.0.21"
-    "@0x/contract-addresses" "^6.0.0"
-    "@0x/contract-wrappers" "^13.15.0"
-    "@0x/json-schemas" "^5.4.1"
-    "@0x/subproviders" "^6.4.1"
-    "@0x/utils" "^6.2.0"
-    "@0x/web3-wrapper" "^7.4.1"
-    chai "^4.0.1"
-    ethereumjs-util "^5.1.1"
-    ethers "~4.0.4"
-    lodash "^4.17.11"
-
 "@0x/quote-server@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@0x/quote-server/-/quote-server-5.0.0.tgz#15554099bdfdf71e2910430860257d622f24f703"
@@ -979,10 +871,9 @@
     express-async-handler "^1.1.4"
     http-status-codes "^1.4.0"
 
-"@0x/sol-compiler@^4.6.1", "@0x/sol-compiler@^4.7.2":
+"@0x/sol-compiler@^4.7.2":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@0x/sol-compiler/-/sol-compiler-4.7.2.tgz#322e3061382f3c333a0f96999abd488c02800b87"
-  integrity sha512-FcLdz5lfGNRw2whvoUCFouRYX5FxYJ2TDDiHOTinJNYa5cjorg7/RVWynhyg06eOTTjDPRgQ5cXRdg/hxDkjpQ==
   dependencies:
     "@0x/assert" "^3.0.26"
     "@0x/json-schemas" "^6.1.2"
@@ -1011,7 +902,6 @@
 "@0x/sol-coverage@^4.0.36":
   version "4.0.36"
   resolved "https://registry.yarnpkg.com/@0x/sol-coverage/-/sol-coverage-4.0.36.tgz#11214f73d1f58b71df10501fce5dbe8f22f1861a"
-  integrity sha512-RV17AStk30bB9v74DC45cyv/ky92pCzfwoxGGEpZ1aF36GvtL5lMBp/UkAUTSG8TlV4ZSUs6iXWhmj50eAnxOw==
   dependencies:
     "@0x/sol-tracing-utils" "^7.2.2"
     "@0x/subproviders" "^6.5.2"
@@ -1026,7 +916,6 @@
 "@0x/sol-profiler@^4.1.26":
   version "4.1.26"
   resolved "https://registry.yarnpkg.com/@0x/sol-profiler/-/sol-profiler-4.1.26.tgz#dc5a590f902ae5652295ef06895ad21743295144"
-  integrity sha512-F+tm9xtXZ4RWEgzpC3Xf15QaKNxYML5kiiLM0pY4Qf1bZOZ+aXFZm8O9wnhWKa9G5ZphHs8T/RKAwZnFQ2QGVA==
   dependencies:
     "@0x/sol-tracing-utils" "^7.2.2"
     "@0x/subproviders" "^6.5.2"
@@ -1041,7 +930,6 @@
 "@0x/sol-resolver@^3.1.8":
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/@0x/sol-resolver/-/sol-resolver-3.1.8.tgz#eaaaf17052e88213e55daf2c6e39a585cc16fa0a"
-  integrity sha512-17PdOpBSLDtlBAUaIdZHWOBXFgcCrr+I0bRxlPg9mfefsJK6+0QdFLWZS35WLLnp8NJw6AeMRb13lBsY0EUuJQ==
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/typescript-typings" "^5.2.0"
@@ -1051,7 +939,6 @@
 "@0x/sol-trace@^3.0.36":
   version "3.0.36"
   resolved "https://registry.yarnpkg.com/@0x/sol-trace/-/sol-trace-3.0.36.tgz#f1bd31b4c13b17abfec8e674896c64b8cdb67cfd"
-  integrity sha512-JyzaPAij4+N3qo1Iv7i2rwSBr0UTTAmbz0tNC9zBK8iY9emkFGWNBKRdgiqdBScTWCe8eZ0MNbG+O1auXwKw8g==
   dependencies:
     "@0x/sol-tracing-utils" "^7.2.2"
     "@0x/subproviders" "^6.5.2"
@@ -1067,7 +954,6 @@
 "@0x/sol-tracing-utils@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@0x/sol-tracing-utils/-/sol-tracing-utils-7.2.2.tgz#330246387c8d6ad78828752d2a23e9680d8fe7b6"
-  integrity sha512-TM/0utPA1xJ5IJsuimHEU83lz63wQqasXuwU6l5J5Dn0F11yITohJaIMGfisZKsp9y5Y728F6t+moY7VebeiKw==
   dependencies:
     "@0x/dev-utils" "^4.2.6"
     "@0x/sol-compiler" "^4.7.2"
@@ -1120,10 +1006,9 @@
   optionalDependencies:
     "@ledgerhq/hw-transport-node-hid" "^4.3.0"
 
-"@0x/subproviders@^6.4.1", "@0x/subproviders@^6.5.2":
+"@0x/subproviders@^6.5.2":
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/@0x/subproviders/-/subproviders-6.5.2.tgz#4734759b042808cba09fa6591ab645ec67262a7a"
-  integrity sha512-6/CXRnIr8Apmy2RqVIncKvLrDHp8RQWOL6zzwwb2FJznvTOBNNs3aHi0qVly65xIMwwlfOhA4D+oJ6h6XuEffQ==
   dependencies:
     "@0x/assert" "^3.0.26"
     "@0x/types" "^3.3.3"
@@ -1166,7 +1051,6 @@
 "@0x/tslint-config@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@0x/tslint-config/-/tslint-config-4.1.4.tgz#559cf717bf1b67d78d3eb42a0039c895e3d7daa5"
-  integrity sha512-4fk+CNTzWjdQ4cBivAEGbBDpPvkM771W04vQjN8qO3NMUsI0SavpbRqQQemZD+Ek+dvgxV9TEt0iEwE0PZN72w==
   dependencies:
     "@types/node" "12.12.54"
     lodash "^4.17.11"
@@ -1286,7 +1170,7 @@
     js-sha3 "^0.7.0"
     lodash "^4.17.11"
 
-"@0x/utils@^6.4.3":
+"@0x/utils@^6.4.2", "@0x/utils@^6.4.3":
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.3.tgz#d7c710a8d8b8f2ee3a4e324dc71423078d93ff37"
   dependencies:
@@ -1319,10 +1203,9 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/web3-wrapper@^7.4.1", "@0x/web3-wrapper@^7.5.2":
+"@0x/web3-wrapper@^7.5.2":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.2.tgz#135a1bc6a5cc4e3841bb11d8e82c3ee9db82dd10"
-  integrity sha512-kfYNYniQV2FRMRKfVgin1+ZBiWPeCxypfvrK2wE6TZif49IG35Ag+fX0IR9PM1fg1QbjvqmA5SzDhJ9SieymGQ==
   dependencies:
     "@0x/assert" "^3.0.26"
     "@0x/json-schemas" "^6.1.2"
@@ -1424,7 +1307,6 @@
 "@ethereumjs/common@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.2.0.tgz#850a3e3e594ee707ad8d44a11e8152fb62450535"
-  integrity sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==
   dependencies:
     crc-32 "^1.2.0"
     ethereumjs-util "^7.0.9"
@@ -1432,7 +1314,6 @@
 "@ethereumjs/tx@^3.1.3":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.4.tgz#04cf9e9406da5f04a1a26c458744641f4b4b8dd0"
-  integrity sha512-6cJpmmjCpG5ZVN9NJYtWvmrEQcevw9DIR8hj2ca2PszD2fxbIFXky3Z37gpf8S6u0Npv09kG8It+G4xjydZVLg==
   dependencies:
     "@ethereumjs/common" "^2.2.0"
     ethereumjs-util "^7.0.10"
@@ -4932,7 +4813,6 @@ coveralls@^3.0.0:
 crc-32@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
-  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
   dependencies:
     exit-on-epipe "~1.0.1"
     printj "~1.1.0"
@@ -6191,7 +6071,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.10:
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.9:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
   dependencies:
@@ -6370,7 +6250,6 @@ execa@^1.0.0:
 exit-on-epipe@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
-  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -10659,7 +10538,6 @@ prettyjson@^1.1.2:
 printj@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
-  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -10810,9 +10688,9 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-"publish-release@git+https://github.com/0xProject/publish-release.git#3f8be1105a356527f4b362ff456d94bf9a82f2ed":
+"publish-release@https://github.com/0xProject/publish-release.git#3f8be1105a356527f4b362ff456d94bf9a82f2ed":
   version "1.3.3"
-  resolved "git+https://github.com/0xProject/publish-release.git#3f8be1105a356527f4b362ff456d94bf9a82f2ed"
+  resolved "https://github.com/0xProject/publish-release.git#3f8be1105a356527f4b362ff456d94bf9a82f2ed"
   dependencies:
     async "^0.9.0"
     ghauth "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6533,9 +6533,9 @@ fake-merkle-patricia-tree@^1.0.1:
   dependencies:
     checkpoint-store "^1.1.0"
 
-fast-abi@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/fast-abi/-/fast-abi-0.0.1.tgz#c61292871800059eeaa649478fe51481262eaec3"
+fast-abi@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/fast-abi/-/fast-abi-0.0.2.tgz#da5f796fd7c7b0c966d916ee21daae3eca61c07c"
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.4"
     neon-cli "^0.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,7 +643,7 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@0x/abi-gen@^5.5.0", "@0x/abi-gen@^5.5.2":
+"@0x/abi-gen@^5.5.2", "@0x/abi-gen@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.6.0.tgz#2b022efe77a35f5589624633d880d794d0a16bde"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,28 +643,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@0x/abi-gen@0xProject/gitpkg-registry#0x-abi-gen-v5.5.2-e38f67b9c":
-  version "5.5.2"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/4afe7e79f22c42c606f88e5e80dadf695c4018e7"
-  dependencies:
-    "@0x/types" "^3.3.3"
-    "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.2"
-    "@types/node" "12.12.54"
-    "@types/toposort" "^2.0.1"
-    chalk "^2.3.0"
-    change-case "^3.0.2"
-    cli-format "^3.0.9"
-    ethereum-types "^3.5.0"
-    glob "^7.1.2"
-    handlebars "^4.1.2"
-    lodash "^4.17.11"
-    mkdirp "^0.5.1"
-    tmp "^0.0.33"
-    to-snake-case "^1.0.0"
-    toposort "^2.0.2"
-    yargs "^10.0.3"
-
 "@0x/abi-gen@^5.4.21":
   version "5.4.21"
   resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.4.21.tgz#96705962c75e116bd5050784287012ede4607564"
@@ -678,6 +656,28 @@
     change-case "^3.0.2"
     cli-format "^3.0.9"
     ethereum-types "^3.4.0"
+    glob "^7.1.2"
+    handlebars "^4.1.2"
+    lodash "^4.17.11"
+    mkdirp "^0.5.1"
+    tmp "^0.0.33"
+    to-snake-case "^1.0.0"
+    toposort "^2.0.2"
+    yargs "^10.0.3"
+
+"@0x/abi-gen@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.6.0.tgz#2b022efe77a35f5589624633d880d794d0a16bde"
+  dependencies:
+    "@0x/types" "^3.3.3"
+    "@0x/typescript-typings" "^5.2.0"
+    "@0x/utils" "^6.4.3"
+    "@types/node" "12.12.54"
+    "@types/toposort" "^2.0.1"
+    chalk "^2.3.0"
+    change-case "^3.0.2"
+    cli-format "^3.0.9"
+    ethereum-types "^3.5.0"
     glob "^7.1.2"
     handlebars "^4.1.2"
     lodash "^4.17.11"
@@ -721,33 +721,16 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/assert@^3.0.26":
-  version "3.0.26"
-  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.26.tgz#c9c3209e093c5fcbb5ff8d3b8f767d35c87195fc"
+"@0x/assert@^3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.27.tgz#a4e54e5c1703c276689a21c935ecd24b2be292b9"
   dependencies:
-    "@0x/json-schemas" "^6.1.2"
+    "@0x/json-schemas" "^6.1.3"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.2"
+    "@0x/utils" "^6.4.3"
     "@types/node" "12.12.54"
     lodash "^4.17.11"
     valid-url "^1.0.9"
-
-"@0x/base-contract@0xProject/gitpkg-registry#0x-base-contract-v6.3.2-e38f67b9c":
-  version "6.3.2"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/91f7a5eb72e1c8607d766bcea6394d04ce71015c"
-  dependencies:
-    "@0x/assert" "^3.0.26"
-    "@0x/json-schemas" "^6.1.2"
-    "@0x/utils" "^6.4.2"
-    "@0x/web3-wrapper" "^7.5.2"
-    "@types/node" "12.12.54"
-    ethereumjs-account "^3.0.0"
-    ethereumjs-blockstream "^7.0.0"
-    ethereumjs-util "^7.0.10"
-    ethereumjs-vm "^4.2.0"
-    ethers "~4.0.4"
-    js-sha3 "^0.7.0"
-    uuid "^3.3.2"
 
 "@0x/base-contract@^6.2.18":
   version "6.2.18"
@@ -761,6 +744,23 @@
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
     ethereumjs-util "^5.1.1"
+    ethereumjs-vm "^4.2.0"
+    ethers "~4.0.4"
+    js-sha3 "^0.7.0"
+    uuid "^3.3.2"
+
+"@0x/base-contract@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.4.0.tgz#7ffcb18b0b8d522545074cada1f4d62dce0a88ec"
+  dependencies:
+    "@0x/assert" "^3.0.27"
+    "@0x/json-schemas" "^6.1.3"
+    "@0x/utils" "^6.4.3"
+    "@0x/web3-wrapper" "^7.5.3"
+    "@types/node" "12.12.54"
+    ethereumjs-account "^3.0.0"
+    ethereumjs-blockstream "^7.0.0"
+    ethereumjs-util "^7.0.10"
     ethereumjs-vm "^4.2.0"
     ethers "~4.0.4"
     js-sha3 "^0.7.0"
@@ -867,9 +867,9 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0x/json-schemas@^6.1.2":
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.2.tgz#e25c8ba453128a529bb95973a631714ec9127356"
+"@0x/json-schemas@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.3.tgz#da71ed2e50ae6813a6d4d0fe5f8ad69b8e6a7435"
   dependencies:
     "@0x/typescript-typings" "^5.2.0"
     "@types/node" "12.12.54"
@@ -1286,9 +1286,9 @@
     js-sha3 "^0.7.0"
     lodash "^4.17.11"
 
-"@0x/utils@^6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.2.tgz#b5d86854383bfe4a3fccdcb8e70aad2efde58250"
+"@0x/utils@^6.4.3":
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.3.tgz#d7c710a8d8b8f2ee3a4e324dc71423078d93ff37"
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/typescript-typings" "^5.2.0"
@@ -1334,14 +1334,14 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/web3-wrapper@^7.5.2":
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.2.tgz#135a1bc6a5cc4e3841bb11d8e82c3ee9db82dd10"
+"@0x/web3-wrapper@^7.5.3":
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.3.tgz#f36c3a2e5ffcbca2b3deef1a15e7485eb91dba7e"
   dependencies:
-    "@0x/assert" "^3.0.26"
-    "@0x/json-schemas" "^6.1.2"
+    "@0x/assert" "^3.0.27"
+    "@0x/json-schemas" "^6.1.3"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.2"
+    "@0x/utils" "^6.4.3"
     "@types/node" "12.12.54"
     ethereum-types "^3.5.0"
     ethereumjs-util "^7.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,14 +643,13 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@0x/abi-gen@^5.5.2":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.5.2.tgz#541d07a9ff93017eaa4ee25b918145ca93619135"
-  integrity sha512-KSKiQTvdnlvRxDhplUQGfmfymnupMalKU7hJoacnDlr91x82PTN9hZi1RyXTb+mBNv6vxqPO4G6abfSE1sr55A==
+"@0x/abi-gen@0xProject/gitpkg-registry#0x-abi-gen-v5.5.1-b78b5e2d4":
+  version "5.5.1"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/53209a8160f78212e54977d9cbc56a340f698907"
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.2"
+    "@0x/utils" "^6.4.1"
     "@types/node" "12.12.54"
     "@types/toposort" "^2.0.1"
     chalk "^2.3.0"
@@ -666,19 +665,19 @@
     toposort "^2.0.2"
     yargs "^10.0.3"
 
-"@0x/abi-gen@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.5.0.tgz#21d15b79e0d8e3377e8b06ce440fea0528d8f021"
+"@0x/abi-gen@^5.4.21":
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-5.4.21.tgz#96705962c75e116bd5050784287012ede4607564"
   dependencies:
-    "@0x/types" "^3.3.3"
-    "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.0"
+    "@0x/types" "^3.3.1"
+    "@0x/typescript-typings" "^5.1.6"
+    "@0x/utils" "^6.2.0"
     "@types/node" "12.12.54"
     "@types/toposort" "^2.0.1"
     chalk "^2.3.0"
     change-case "^3.0.2"
     cli-format "^3.0.9"
-    ethereum-types "^3.5.0"
+    ethereum-types "^3.4.0"
     glob "^7.1.2"
     handlebars "^4.1.2"
     lodash "^4.17.11"
@@ -722,60 +721,25 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/assert@^3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.24.tgz#e1153b0c156ed8f7caec6b221f9d7a5997bdcae1"
+"@0x/assert@^3.0.25":
+  version "3.0.25"
+  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.25.tgz#19bb7633ea88c7c3aeff37e84c664916f2c5095b"
   dependencies:
-    "@0x/json-schemas" "^6.1.0"
+    "@0x/json-schemas" "^6.1.1"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.0"
+    "@0x/utils" "^6.4.1"
     "@types/node" "12.12.54"
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/base-contract@^6.2.18":
-  version "6.2.18"
-  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.2.18.tgz#d092de93d52d8cf8e5d4600d9ca852421322ab38"
+"@0x/base-contract@0xProject/gitpkg-registry#0x-base-contract-v6.3.1-b78b5e2d4":
+  version "6.3.1"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/9ca089aa99c91335eb66fa59fffafbb12228dc2a"
   dependencies:
-    "@0x/assert" "^3.0.21"
-    "@0x/base-contract" "^6.2.18"
-    "@0x/contract-addresses" "^6.0.0"
-    "@0x/contract-wrappers" "^13.15.0"
-    "@0x/contracts-erc20" "^3.3.6"
-    "@0x/contracts-zero-ex" "^0.22.0"
-    "@0x/dev-utils" "^4.2.1"
-    "@0x/json-schemas" "^5.4.1"
-    "@0x/protocol-utils" "^1.5.0"
-    "@0x/quote-server" "^5.0.0"
-    "@0x/types" "^3.3.1"
-    "@0x/typescript-typings" "^5.1.6"
-    "@0x/utils" "^6.2.0"
-    "@0x/web3-wrapper" "^7.4.1"
-    "@balancer-labs/sor" "0.3.2"
-    "@bancor/sdk" "0.2.9"
-    "@ethersproject/abi" "^5.0.1"
-    "@ethersproject/address" "^5.0.1"
-    "@ethersproject/contracts" "^5.0.1"
-    "@ethersproject/providers" "^5.0.4"
-    "@ethersproject/strings" "^5.0.10"
-    axios "^0.21.1"
-    axios-mock-adapter "^1.19.0"
-    cream-sor "^0.3.3"
-    decimal.js "^10.2.0"
-    ethereum-types "^3.4.0"
-    ethereumjs-util "^5.1.1"
-    heartbeats "^5.0.1"
-    lodash "^4.17.11"
-
-"@0x/base-contract@^6.2.18", "@0x/base-contract@^6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.3.2.tgz#6d0bd9fe9720ac326c899d55635c594abe5381d4"
-  integrity sha512-OzveJvKfY8qvUAWboPMAnpOcSW2r4rEEJeAZx0zuTuSyLUHAOAQWgpgrwat9Pu4lYAgNryQalOBds7ERxuPt+Q==
-  dependencies:
-    "@0x/assert" "^3.0.26"
-    "@0x/json-schemas" "^6.1.2"
-    "@0x/utils" "^6.4.2"
-    "@0x/web3-wrapper" "^7.5.2"
+    "@0x/assert" "^3.0.25"
+    "@0x/json-schemas" "^6.1.1"
+    "@0x/utils" "^6.4.1"
+    "@0x/web3-wrapper" "^7.5.1"
     "@types/node" "12.12.54"
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
@@ -785,18 +749,18 @@
     js-sha3 "^0.7.0"
     uuid "^3.3.2"
 
-"@0x/base-contract@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.3.0.tgz#dfa9205761580e5b5f4c3db8f74ecaa7606b58af"
+"@0x/base-contract@^6.2.18":
+  version "6.2.18"
+  resolved "https://registry.yarnpkg.com/@0x/base-contract/-/base-contract-6.2.18.tgz#d092de93d52d8cf8e5d4600d9ca852421322ab38"
   dependencies:
-    "@0x/assert" "^3.0.24"
-    "@0x/json-schemas" "^6.1.0"
-    "@0x/utils" "^6.4.0"
-    "@0x/web3-wrapper" "^7.5.0"
+    "@0x/assert" "^3.0.21"
+    "@0x/json-schemas" "^5.4.1"
+    "@0x/utils" "^6.2.0"
+    "@0x/web3-wrapper" "^7.4.1"
     "@types/node" "12.12.54"
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
-    ethereumjs-util "^7.0.10"
+    ethereumjs-util "^5.1.1"
     ethereumjs-vm "^4.2.0"
     ethers "~4.0.4"
     js-sha3 "^0.7.0"
@@ -903,9 +867,9 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0x/json-schemas@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.0.tgz#5b238bc4e3da06638534e5e5f53ab89a41913a71"
+"@0x/json-schemas@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.1.tgz#4311a4d546c315ff2a8ade9f9482c3a6cb0a0d90"
   dependencies:
     "@0x/typescript-typings" "^5.2.0"
     "@types/node" "12.12.54"
@@ -1341,6 +1305,25 @@
     js-sha3 "^0.7.0"
     lodash "^4.17.11"
 
+"@0x/utils@^6.4.1":
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.1.tgz#f194164c8f6ab514978415eec4d28bfcffa99281"
+  dependencies:
+    "@0x/types" "^3.3.3"
+    "@0x/typescript-typings" "^5.2.0"
+    "@types/mocha" "^5.2.7"
+    "@types/node" "12.12.54"
+    abortcontroller-polyfill "^1.1.9"
+    bignumber.js "~9.0.0"
+    chalk "^2.3.0"
+    detect-node "2.0.3"
+    ethereum-types "^3.5.0"
+    ethereumjs-util "^7.0.10"
+    ethers "~4.0.4"
+    isomorphic-fetch "2.2.1"
+    js-sha3 "^0.7.0"
+    lodash "^4.17.11"
+
 "@0x/web3-wrapper@^7.2.8":
   version "7.2.8"
   resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.2.8.tgz#7df4c52e358594338f8dbe76b1490a5c4c423633"
@@ -1370,14 +1353,14 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/web3-wrapper@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.0.tgz#e33a4400fb511389b2e67e6ffb9df290f6842ec4"
+"@0x/web3-wrapper@^7.5.1":
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.1.tgz#e2714ff643be8acaf3a6468f3bc734dde793ce8d"
   dependencies:
-    "@0x/assert" "^3.0.24"
-    "@0x/json-schemas" "^6.1.0"
+    "@0x/assert" "^3.0.25"
+    "@0x/json-schemas" "^6.1.1"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.0"
+    "@0x/utils" "^6.4.1"
     "@types/node" "12.12.54"
     ethereum-types "^3.5.0"
     ethereumjs-util "^7.0.10"
@@ -2510,6 +2493,20 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@mapbox/node-pre-gyp@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.4.tgz#6c76e7a40138eac39e1a4dc869a083e43e236c00"
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -2948,6 +2945,12 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  dependencies:
+    debug "4"
+
 agent-base@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
@@ -2984,6 +2987,12 @@ ansi-colors@4.1.1:
 ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+
+ansi-escapes@^4.2.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  dependencies:
+    type-fest "^0.21.3"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -3105,6 +3114,14 @@ arr-flatten@^1.0.1, arr-flatten@^1.1.0:
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
+array-back@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+
+array-back@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.1.tgz#9b80312935a52062e1a233a9c7abeb5481b30e90"
 
 array-differ@^2.0.3:
   version "2.1.0"
@@ -4346,6 +4363,13 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 change-case@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
@@ -4430,6 +4454,10 @@ chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -4474,6 +4502,12 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  dependencies:
+    restore-cursor "^3.1.0"
+
 cli-format@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/cli-format/-/cli-format-3.0.9.tgz#ea2cf6df891a8deaaa0dae7d9b8bd21dd8661bb2"
@@ -4497,6 +4531,10 @@ cli-spinners@^1.0.1:
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
 
 cliff@0.1.9:
   version "0.1.9"
@@ -4649,6 +4687,30 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
 command-exists@^1.2.8:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+
+command-line-args@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
+  dependencies:
+    array-back "^3.0.1"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-commands@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/command-line-commands/-/command-line-commands-3.0.2.tgz#53872a1181db837f21906b1228e260a4eeb42ee4"
+  dependencies:
+    array-back "^4.0.1"
+
+command-line-usage@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
+  dependencies:
+    array-back "^4.0.1"
+    chalk "^2.4.2"
+    table-layout "^1.0.1"
+    typical "^5.2.0"
 
 commander@2.11.0:
   version "2.11.0"
@@ -5060,6 +5122,12 @@ debug@3.2.6, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@4:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  dependencies:
+    ms "2.1.2"
+
 debug@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -5203,7 +5271,7 @@ deep-equal@~0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
 
-deep-extend@^0.6.0:
+deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
@@ -6465,6 +6533,14 @@ fake-merkle-patricia-tree@^1.0.1:
   dependencies:
     checkpoint-store "^1.1.0"
 
+fast-abi@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/fast-abi/-/fast-abi-0.0.1.tgz#c61292871800059eeaa649478fe51481262eaec3"
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.4"
+    neon-cli "^0.8.0"
+    uuid "^8.3.2"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -6515,6 +6591,12 @@ figlet@^1.1.1:
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -6588,6 +6670,12 @@ find-cache-dir@^0.1.1:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  dependencies:
+    array-back "^3.0.1"
 
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
@@ -6804,6 +6892,12 @@ fs-minipass@^1.2.5:
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
   dependencies:
     minipass "^2.6.0"
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  dependencies:
+    minipass "^3.0.0"
 
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
@@ -7023,6 +7117,12 @@ ghauth@^2.0.0:
     mkdirp "~0.5.0"
     read "~1.0.5"
     xtend "~4.0.0"
+
+git-config@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/git-config/-/git-config-0.0.7.tgz#a9c8a3ef07a776c3d72261356d8b727b62202b28"
+  dependencies:
+    iniparser "~1.0.5"
 
 git-raw-commits@2.0.0:
   version "2.0.0"
@@ -7498,6 +7598,13 @@ https-proxy-agent@^2.2.3:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -7625,6 +7732,10 @@ ini@1.x.x, ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
+iniparser@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
+
 init-package-json@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-1.10.3.tgz#45ffe2f610a8ca134f2bd1db5637b235070f6cbe"
@@ -7654,6 +7765,24 @@ inquirer@^6.2.0, inquirer@^6.2.2:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 interpret@^1.0.0:
@@ -8656,6 +8785,10 @@ lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -8712,6 +8845,10 @@ lodash.values@^4.3.0:
 lodash@4.17.20, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+
+lodash@^4.17.19:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
 
 log-driver@^1.2.7:
   version "1.2.7"
@@ -8805,6 +8942,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  dependencies:
+    yallist "^4.0.0"
+
 ltgt@^2.1.2, ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -8834,6 +8977,12 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-dir@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  dependencies:
+    semver "^6.0.0"
+
 make-fetch-happen@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz#aa8387104f2687edca01c8687ee45013d02d19bd"
@@ -8853,6 +9002,10 @@ make-fetch-happen@^5.0.0:
 make-promises-safe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/make-promises-safe/-/make-promises-safe-1.1.0.tgz#b4d28c61ef8ad5502f38dbb3a0ee89627f76ad61"
+
+make-promises-safe@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/make-promises-safe/-/make-promises-safe-5.1.0.tgz#dd9d311f555bcaa144f12e225b3d37785f0aa8f2"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -9089,7 +9242,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
 
@@ -9159,11 +9312,24 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
   dependencies:
     minipass "^2.9.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -9197,7 +9363,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
 
@@ -9375,7 +9541,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
 
@@ -9454,6 +9620,25 @@ negotiator@0.6.2:
 neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+
+neon-cli@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.8.0.tgz#bca2e1cbc9706c65bf736a7057e6b3bf28f55857"
+  dependencies:
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-commands "^3.0.1"
+    command-line-usage "^6.1.0"
+    git-config "0.0.7"
+    handlebars "^4.7.6"
+    inquirer "^7.3.3"
+    make-promises-safe "^5.1.0"
+    rimraf "^3.0.2"
+    semver "^7.3.2"
+    toml "^3.0.0"
+    ts-typed-json "^0.3.2"
+    validate-npm-package-license "^3.0.4"
+    validate-npm-package-name "^3.0.0"
 
 next-tick@~1.0.0:
   version "1.0.0"
@@ -9596,6 +9781,12 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0, "normalize-package-data@~1.0.1 || ^2.0.0":
   version "2.5.0"
@@ -9905,6 +10096,12 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
+
+onetime@^5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  dependencies:
+    mimic-fn "^2.1.0"
 
 optimist@0.2:
   version "0.2.8"
@@ -11002,6 +11199,10 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+
 reflect-metadata@^0.1.10, reflect-metadata@^0.1.12:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -11208,6 +11409,13 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 resumer@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
@@ -11242,6 +11450,12 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -11255,7 +11469,7 @@ rlp@^2.0.0, rlp@^2.2.1, rlp@^2.2.2, rlp@^2.2.3, rlp@^2.2.4:
   dependencies:
     bn.js "^4.11.1"
 
-run-async@^2.2.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
 
@@ -11272,6 +11486,12 @@ rustbn.js@~0.2.0:
 rxjs@^6.4.0, rxjs@^6.5.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.0:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   dependencies:
     tslib "^1.9.0"
 
@@ -11408,6 +11628,12 @@ semver@^6.0.0, semver@^6.2.0:
 semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+
+semver@^7.3.4:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.4.1:
   version "5.4.1"
@@ -11918,6 +12144,14 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
@@ -12140,6 +12374,15 @@ swarm-js@^0.1.40:
     tar "^4.0.2"
     xhr-request "^1.0.1"
 
+table-layout@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  dependencies:
+    array-back "^4.0.1"
+    deep-extend "~0.6.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -12231,6 +12474,17 @@ tar@^4, tar@^4.0.2, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+tar@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -12424,6 +12678,10 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+
 toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
@@ -12468,6 +12726,10 @@ truffle@^5.0.32:
     app-module-path "^2.2.0"
     mocha "8.1.2"
     original-require "1.0.1"
+
+ts-typed-json@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ts-typed-json/-/ts-typed-json-0.3.2.tgz#f4f20f45950bae0a383857f7b0a94187eca1b56a"
 
 tslib@1.9.0:
   version "1.9.0"
@@ -12557,6 +12819,10 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
 type-fest@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
 
 type-fest@^0.3.0:
   version "0.3.1"
@@ -12678,6 +12944,14 @@ typewise@^1.0.3:
 typewiselite@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typewiselite/-/typewiselite-1.0.0.tgz#c8882fa1bb1092c06005a97f34ef5c8508e3664e"
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
 
 u2f-api@0.2.7:
   version "0.2.7"
@@ -12913,11 +13187,15 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+
 valid-url@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
 
-validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:
@@ -13753,6 +14031,13 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  dependencies:
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
+
 workerpool@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
@@ -13934,6 +14219,10 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
 
 yargonaut@^1.1.2:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,13 +643,13 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@0x/abi-gen@0xProject/gitpkg-registry#0x-abi-gen-v5.5.1-b78b5e2d4":
-  version "5.5.1"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/53209a8160f78212e54977d9cbc56a340f698907"
+"@0x/abi-gen@0xProject/gitpkg-registry#0x-abi-gen-v5.5.2-e38f67b9c":
+  version "5.5.2"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/4afe7e79f22c42c606f88e5e80dadf695c4018e7"
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.1"
+    "@0x/utils" "^6.4.2"
     "@types/node" "12.12.54"
     "@types/toposort" "^2.0.1"
     chalk "^2.3.0"
@@ -721,25 +721,25 @@
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/assert@^3.0.25":
-  version "3.0.25"
-  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.25.tgz#19bb7633ea88c7c3aeff37e84c664916f2c5095b"
+"@0x/assert@^3.0.26":
+  version "3.0.26"
+  resolved "https://registry.yarnpkg.com/@0x/assert/-/assert-3.0.26.tgz#c9c3209e093c5fcbb5ff8d3b8f767d35c87195fc"
   dependencies:
-    "@0x/json-schemas" "^6.1.1"
+    "@0x/json-schemas" "^6.1.2"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.1"
+    "@0x/utils" "^6.4.2"
     "@types/node" "12.12.54"
     lodash "^4.17.11"
     valid-url "^1.0.9"
 
-"@0x/base-contract@0xProject/gitpkg-registry#0x-base-contract-v6.3.1-b78b5e2d4":
-  version "6.3.1"
-  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/9ca089aa99c91335eb66fa59fffafbb12228dc2a"
+"@0x/base-contract@0xProject/gitpkg-registry#0x-base-contract-v6.3.2-e38f67b9c":
+  version "6.3.2"
+  resolved "https://codeload.github.com/0xProject/gitpkg-registry/tar.gz/91f7a5eb72e1c8607d766bcea6394d04ce71015c"
   dependencies:
-    "@0x/assert" "^3.0.25"
-    "@0x/json-schemas" "^6.1.1"
-    "@0x/utils" "^6.4.1"
-    "@0x/web3-wrapper" "^7.5.1"
+    "@0x/assert" "^3.0.26"
+    "@0x/json-schemas" "^6.1.2"
+    "@0x/utils" "^6.4.2"
+    "@0x/web3-wrapper" "^7.5.2"
     "@types/node" "12.12.54"
     ethereumjs-account "^3.0.0"
     ethereumjs-blockstream "^7.0.0"
@@ -867,9 +867,9 @@
     jsonschema "^1.2.0"
     lodash.values "^4.3.0"
 
-"@0x/json-schemas@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.1.tgz#4311a4d546c315ff2a8ade9f9482c3a6cb0a0d90"
+"@0x/json-schemas@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@0x/json-schemas/-/json-schemas-6.1.2.tgz#e25c8ba453128a529bb95973a631714ec9127356"
   dependencies:
     "@0x/typescript-typings" "^5.2.0"
     "@types/node" "12.12.54"
@@ -1286,28 +1286,9 @@
     js-sha3 "^0.7.0"
     lodash "^4.17.11"
 
-"@0x/utils@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.0.tgz#942505ae628e00ba865ecf65885f3cecc293fde9"
-  dependencies:
-    "@0x/types" "^3.3.3"
-    "@0x/typescript-typings" "^5.2.0"
-    "@types/mocha" "^5.2.7"
-    "@types/node" "12.12.54"
-    abortcontroller-polyfill "^1.1.9"
-    bignumber.js "~9.0.0"
-    chalk "^2.3.0"
-    detect-node "2.0.3"
-    ethereum-types "^3.5.0"
-    ethereumjs-util "^7.0.10"
-    ethers "~4.0.4"
-    isomorphic-fetch "2.2.1"
-    js-sha3 "^0.7.0"
-    lodash "^4.17.11"
-
-"@0x/utils@^6.4.1":
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.1.tgz#f194164c8f6ab514978415eec4d28bfcffa99281"
+"@0x/utils@^6.4.2":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@0x/utils/-/utils-6.4.2.tgz#b5d86854383bfe4a3fccdcb8e70aad2efde58250"
   dependencies:
     "@0x/types" "^3.3.3"
     "@0x/typescript-typings" "^5.2.0"
@@ -1353,14 +1334,14 @@
     ethers "~4.0.4"
     lodash "^4.17.11"
 
-"@0x/web3-wrapper@^7.5.1":
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.1.tgz#e2714ff643be8acaf3a6468f3bc734dde793ce8d"
+"@0x/web3-wrapper@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@0x/web3-wrapper/-/web3-wrapper-7.5.2.tgz#135a1bc6a5cc4e3841bb11d8e82c3ee9db82dd10"
   dependencies:
-    "@0x/assert" "^3.0.25"
-    "@0x/json-schemas" "^6.1.1"
+    "@0x/assert" "^3.0.26"
+    "@0x/json-schemas" "^6.1.2"
     "@0x/typescript-typings" "^5.2.0"
-    "@0x/utils" "^6.4.1"
+    "@0x/utils" "^6.4.2"
     "@types/node" "12.12.54"
     ethereum-types "^3.5.0"
     ethereumjs-util "^7.0.10"


### PR DESCRIPTION
## Description

TKR-24

[Simbot sells](https://metabase.spaceship.0x.org/dashboard/186?run_id=jacob-fast-abi--mainnet&adjusted_amount_bought_win_tolerance__bps_=0.5)
### Prune paths
<!--- Describe your changes in detail -->
Prune paths where the rate (`bestRate`) when selling a fractional amount is less than the adjusted complete rate of selling the entire amount (`adjustedCompleteRate`) to the best source (sorted by `adjustedCompleteRate`).

Since selling anything to this path wouldn't result in any overall improvement. We can cut down on the paths to compare.


We should see no regressions, only improved response times (there is the small possibility of improved prices as we have more time to search over less paths)

### Fast ABI

Use an ABI encoder/decoder which is more performant than our AbiEncoder (though lacks the transaction gas optimization).
 
## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

```
4000 USDC buy 
  before: 26,
  after: 21
400,000 USDC buy (drops Uni+Sushi, goes hard on Curves + MakerPSM)
  before: 21,
  after: 9
1 ETH sell (drops CryptoCom)
  before: 30,
  after: 26
100 ETH sell (drops Linkswap, Mooni, CryptoCom, Balancer)
  before: 25,
  after: 6
```

```
  MarketOperationUtils tests
    optimization
      100 routes
old: 1759ms 56.85 routes/s
new: 199ms 502.51 routes/s
        ✓ DEX QUOTES BNB/BUSD SMALL (1963ms)
old: 6907ms 14.48 routes/s
new: 370ms 270.27 routes/s
        ✓ DEX QUOTES BNB/BUSD LARGE (7283ms)
old: 1661ms 60.2 routes/s
new: 372ms 268.82 routes/s
        ✓ DEX QUOTES DAI/USDC LARGE (2041ms)
old: 22057ms 4.53 routes/s
new: 18470ms 5.41 routes/s
        ✓ DEX QUOTES ETH/DAI LARGE (40531ms)
old: 22361ms 4.47 routes/s
new: 19078ms 5.24 routes/s
NEW IS LARGER BY 0.005474% 45571513355722468522 units
        ✓ DEX QUOTES ETH/DAI LARGE (FREE GAS) (41442ms)
old: 2285ms 43.76 routes/s
new: 2218ms 45.09 routes/s
        ✓ DEX QUOTES ETH/DAI SMALL (4509ms)
old: 2141ms 46.71 routes/s
new: 2067ms 48.38 routes/s
        ✓ DEX QUOTES ETH/USDC SMALL (4213ms)


  7 passing (2m)
```

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
