### PR TITLE
Apply slippage to non-native orders [TKR-39]

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.5.3",
+        "changes": [
+            {
+                "note": "Apply slippage to bridge orders in consumer",
+                "pr": 198
+            }
+        ]
+    },
+    {
         "timestamp": 1618314654,
         "version": "6.5.2",
         "changes": [

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -591,12 +591,10 @@ function calculateTwoHopQuoteInfo(
                 : secondHopOrder.makerAmount,
             takerAmount: MarketOperation.Sell
                 ? firstHopOrder.takerAmount
-                : // tslint:disable-next-line: binary-expression-operand-order
-                  firstHopOrder.takerAmount.times(1 + slippage).integerValue(),
+                : firstHopOrder.takerAmount.times(1 + slippage).integerValue(),
             totalTakerAmount: MarketOperation.Sell
                 ? firstHopOrder.takerAmount
-                : // tslint:disable-next-line: binary-expression-operand-order
-                  firstHopOrder.takerAmount.times(1 + slippage).integerValue(),
+                : firstHopOrder.takerAmount.times(1 + slippage).integerValue(),
             feeTakerTokenAmount: constants.ZERO_AMOUNT,
             protocolFeeInWeiAmount: constants.ZERO_AMOUNT,
             gas,

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -593,7 +593,10 @@ function calculateTwoHopQuoteInfo(
                 ? firstHopOrder.takerAmount
                 : // tslint:disable-next-line: binary-expression-operand-order
                   firstHopOrder.takerAmount.times(1 + slippage).integerValue(),
-            totalTakerAmount: firstHopOrder.takerAmount,
+            totalTakerAmount: MarketOperation.Sell
+                ? firstHopOrder.takerAmount
+                : // tslint:disable-next-line: binary-expression-operand-order
+                  firstHopOrder.takerAmount.times(1 + slippage).integerValue(),
             feeTakerTokenAmount: constants.ZERO_AMOUNT,
             protocolFeeInWeiAmount: constants.ZERO_AMOUNT,
             gas,

--- a/packages/asset-swapper/src/utils/quote_simulation.ts
+++ b/packages/asset-swapper/src/utils/quote_simulation.ts
@@ -129,11 +129,10 @@ export function simulateWorstCaseFill(quoteInfo: QuoteFillInfo): QuoteFillResult
     };
     // Adjust the output by 1-slippage for the worst case if it is a sell
     // Adjust the output by 1+slippage for the worst case if it is a buy
-    const outputMultiplier =
+    result.output =
         quoteInfo.side === MarketOperation.Sell
-            ? new BigNumber(1).minus(opts.slippage)
-            : new BigNumber(1).plus(opts.slippage);
-    result.output = result.output.times(outputMultiplier).integerValue();
+            ? result.output.times(1 - opts.slippage).integerValue(BigNumber.ROUND_DOWN)
+            : result.output.times(1 + opts.slippage).integerValue(BigNumber.ROUND_UP);
     return fromIntermediateQuoteFillResult(result, quoteInfo);
 }
 

--- a/packages/asset-swapper/tslint.json
+++ b/packages/asset-swapper/tslint.json
@@ -1,7 +1,8 @@
 {
     "extends": ["@0x/tslint-config"],
     "rules": {
-        "max-file-line-count": false
+        "max-file-line-count": false,
+        "binary-expression-operand-order": false
     },
     "linterOptions": {
         "exclude": ["src/artifacts.ts", "test/artifacts.ts"]


### PR DESCRIPTION
## Description

[TKR-39]

Hopefully fixes buy quotes inadvertently filling at 0% slippage when routing through the FQT/multiplex.

Update: it be do
![Figure_1](https://user-images.githubusercontent.com/48803443/114592237-b7d24d00-9c58-11eb-9a12-e51070538f23.png)

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
