### PR TITLE
Fix exchangeProxyGasOverhead used to compute fallback orders

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Add LUSD Curve pool",
                 "pr": 218
+            },
+            {
+                "note": "Fix exchangeProxyGasOverhead for fallback path",
+                "pr": 215
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -560,7 +560,11 @@ export class MarketOperationUtils {
             // We create a fallback path that is exclusive of Native liquidity
             // This is the optimal on-chain path for the entire input amount
             const nonNativeFills = fills.filter(p => p.length > 0 && p[0].source !== ERC20BridgeSource.Native);
-            const nonNativeOptimalPath = await findOptimalPathAsync(side, nonNativeFills, inputAmount, opts.runLimit);
+            const nonNativeOptimalPath = await findOptimalPathAsync(side, nonNativeFills, inputAmount, opts.runLimit, {
+                ...penaltyOpts,
+                exchangeProxyOverhead: (sourceFlags: number) =>
+                    penaltyOpts.exchangeProxyOverhead(sourceFlags | optimalPath.sourceFlags),
+            });
             // Calculate the slippage of on-chain sources compared to the most optimal path
             if (
                 nonNativeOptimalPath !== undefined &&

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -563,6 +563,7 @@ export class MarketOperationUtils {
             const nonNativeOptimalPath = await findOptimalPathAsync(side, nonNativeFills, inputAmount, opts.runLimit, {
                 ...penaltyOpts,
                 exchangeProxyOverhead: (sourceFlags: number) =>
+                    // tslint:disable-next-line: no-bitwise
                     penaltyOpts.exchangeProxyOverhead(sourceFlags | optimalPath.sourceFlags),
             });
             // Calculate the slippage of on-chain sources compared to the most optimal path


### PR DESCRIPTION
## Description
AssetSwapper was defaulting to an exchangeProxyGasOverhead of 0 when computing fallback orders. 
This PR fixes that logic

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
