### PR TITLE
fix: Temporarily remove PancakeV2/Bakery from VIP

### DIFF
--- a/contracts/zero-ex/contracts/src/features/PancakeSwapFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/PancakeSwapFeature.sol
@@ -280,7 +280,7 @@ contract PancakeSwapFeature is
 
                 // Call pair.swap()
                 switch mload(0xA20) // fork
-                    case 1 {
+                    case 2 {
                         mstore(0xB00, BAKERYSWAP_PAIR_SWAP_CALL_SELECTOR_32)
                     }
                     default {

--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "6.9.1",
+        "changes": [
+            {
+                "note": "Temporarily remove PancakeV2 and BakerySwap from VIP"
+            }
+        ]
+    },
+    {
         "version": "6.9.0",
         "changes": [
             {

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -197,8 +197,9 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
             this.chainId === ChainId.BSC &&
             isDirectSwapCompatible(quote, optsWithDefaults, [
                 ERC20BridgeSource.PancakeSwap,
-                ERC20BridgeSource.PancakeSwapV2,
-                ERC20BridgeSource.BakerySwap,
+                // Temporarily removed until latest PancakeSwap VIP has been deployed
+                // ERC20BridgeSource.PancakeSwapV2,
+                // ERC20BridgeSource.BakerySwap,
                 ERC20BridgeSource.SushiSwap,
                 ERC20BridgeSource.ApeSwap,
                 ERC20BridgeSource.CafeSwap,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Need to update all references to forked values as `BakerySwap` is now `2` and `PancakeSwapV2` is `1`

Temporarily disabling VIP for these two sources

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
