### PR TITLE
feat: Balancer V2 load and cache top pools by num swaps on startup [TKR-96]

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -3,6 +3,10 @@
         "version": "6.11.0",
         "changes": [
             {
+                "note": "Add caching for top Balancer V2 pools on startup and during regular intervals",
+                "pr": "228"
+            },
+            {
                 "note": "Tweak compiler settings for smaller sampler bytecode",
                 "pr": 229
             },

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_sor_v2.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_sor_v2.ts
@@ -1,0 +1,149 @@
+import { BigNumber } from '@0x/utils';
+/**
+ * This has been copied from https://github.com/balancer-labs/balancer-sor/blob/john/rc2/src/helpers.ts.
+ * Still awaiting V2 support for @balancer-labs/sor, once full V2 support is shipped we can upgrade sor and delete this file
+ */
+export const parsePoolData = (
+    directPools: SubGraphPoolDictionary,
+    tokenIn: string,
+    tokenOut: string,
+    mostLiquidPoolsFirstHop: SubGraphPool[] = [],
+    mostLiquidPoolsSecondHop: SubGraphPool[] = [],
+    hopTokens: string[] = [],
+): [SubGraphPoolDictionary, Path[]] => {
+    const pathDataList: Path[] = [];
+    const pools: SubGraphPoolDictionary = {};
+
+    // First add direct pair paths
+    // tslint:disable-next-line:forin
+    for (const idKey in directPools) {
+        const p: SubGraphPool = directPools[idKey];
+        // Add pool to the set with all pools (only adds if it's still not present in dict)
+        pools[idKey] = p;
+
+        const swap: Swap = {
+            pool: p.id,
+            tokenIn,
+            tokenOut,
+            tokenInDecimals: 18, // Placeholder for actual decimals
+            tokenOutDecimals: 18,
+        };
+
+        const path: Path = {
+            id: p.id,
+            swaps: [swap],
+        };
+        pathDataList.push(path);
+    }
+
+    // Now add multi-hop paths.
+    // mostLiquidPoolsFirstHop and mostLiquidPoolsSecondHop always has the same
+    // lengh of hopTokens
+    for (let i = 0; i < hopTokens.length; i++) {
+        // Add pools to the set with all pools (only adds if it's still not present in dict)
+        pools[mostLiquidPoolsFirstHop[i].id] = mostLiquidPoolsFirstHop[i];
+        pools[mostLiquidPoolsSecondHop[i].id] = mostLiquidPoolsSecondHop[i];
+
+        const swap1: Swap = {
+            pool: mostLiquidPoolsFirstHop[i].id,
+            tokenIn,
+            tokenOut: hopTokens[i],
+            tokenInDecimals: 18, // Placeholder for actual decimals
+            tokenOutDecimals: 18,
+        };
+
+        const swap2: Swap = {
+            pool: mostLiquidPoolsSecondHop[i].id,
+            tokenIn: hopTokens[i],
+            tokenOut,
+            tokenInDecimals: 18, // Placeholder for actual decimals
+            tokenOutDecimals: 18,
+        };
+
+        const path: Path = {
+            id: mostLiquidPoolsFirstHop[i].id + mostLiquidPoolsSecondHop[i].id, // Path id is the concatenation of the ids of poolFirstHop and poolSecondHop
+            swaps: [swap1, swap2],
+        };
+        pathDataList.push(path);
+    }
+    return [pools, pathDataList];
+};
+
+interface SubGraphPool {
+    id: string;
+    swapFee: string;
+    totalWeight: string;
+    totalShares: string;
+    tokens: SubGraphToken[];
+    tokensList: string[];
+    poolType?: string;
+
+    // Only for stable pools
+    amp: string;
+
+    // Only for element pools
+    lpShares?: BigNumber;
+    time?: BigNumber;
+    principalToken?: string;
+    baseToken?: string;
+}
+
+interface SubGraphPoolDictionary {
+    [poolId: string]: SubGraphPool;
+}
+
+interface SubGraphToken {
+    address: string;
+    balance: string;
+    decimals: string | number;
+    // Stable & Element field
+    weight?: string;
+}
+interface Path {
+    id: string; // pool address if direct path, contactenation of pool addresses if multihop
+    swaps: Swap[];
+    poolPairData?: PoolPairData[];
+    limitAmount?: BigNumber;
+    filterEffectivePrice?: BigNumber; // TODO: This is just used for filtering, maybe there is a better way to filter?
+}
+
+interface Swap {
+    pool: string;
+    tokenIn: string;
+    tokenOut: string;
+    swapAmount?: string;
+    limitReturnAmount?: string;
+    maxPrice?: string;
+    tokenInDecimals: number;
+    tokenOutDecimals: number;
+}
+
+export interface PoolPairData {
+    id: string;
+    poolType?: string; // Todo: make this a mandatory field?
+    pairType?: string; // Todo: make this a mandatory field?
+    tokenIn: string;
+    tokenOut: string;
+    balanceIn?: BigNumber;
+    balanceOut?: BigNumber;
+    decimalsIn: number;
+    decimalsOut: number;
+    swapFee: BigNumber;
+
+    // For weighted & element pools
+    weightIn?: BigNumber;
+    weightOut?: BigNumber;
+
+    // Only for stable pools
+    allBalances: BigNumber[];
+    invariant?: BigNumber;
+    amp?: BigNumber;
+    tokenIndexIn?: number;
+    tokenIndexOut?: number;
+
+    // Only for element pools
+    lpShares?: BigNumber;
+    time?: BigNumber;
+    principalToken?: string;
+    baseToken?: string;
+}

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
@@ -1,19 +1,60 @@
-// import { getPoolsWithTokens, parsePoolData } from '@balancer-labs/sor'; // TODO - upgrade to v2
 import { BigNumber } from '@0x/utils';
+// import { parsePoolData } from '@balancer-labs'; // TODO - upgrade to v2
 import { Pool } from '@balancer-labs/sor/dist/types';
-import { request } from 'graphql-request';
+import { gql, request } from 'graphql-request';
 
-import { BALANCER_MAX_POOLS_FETCHED, BALANCER_V2_SUBGRAPH_URL } from '../constants';
+import { DEFAULT_WARNING_LOGGER } from '../../../constants';
+import { LogFunction } from '../../../types';
+import { BALANCER_MAX_POOLS_FETCHED, BALANCER_TOP_POOLS_FETCHED, BALANCER_V2_SUBGRAPH_URL } from '../constants';
 
+import { parsePoolData } from './balancer_sor_v2';
 import { CacheValue, PoolsCache } from './pools_cache';
 
+// tslint:disable-next-line:custom-no-magic-numbers
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+interface BalancerPoolResponse {
+    id: string;
+    swapFee: string;
+    tokens: Array<{ address: string; decimals: number; balance: string; weight: string; symbol: string }>;
+    tokensList: string[];
+    totalWeight: string;
+    totalShares: string;
+    amp: string | null;
+}
+
 export class BalancerV2PoolsCache extends PoolsCache {
+    private static _parseSubgraphPoolData(pool: any, takerToken: string, makerToken: string): Pool {
+        const tToken = pool.tokens.find((t: any) => t.address === takerToken);
+        const mToken = pool.tokens.find((t: any) => t.address === makerToken);
+        const swap = pool.swaps && pool.swaps[0];
+        const tokenAmountOut = swap ? swap.tokenAmountOut : undefined;
+        const tokenAmountIn = swap ? swap.tokenAmountIn : undefined;
+        const spotPrice =
+            tokenAmountOut && tokenAmountIn ? new BigNumber(tokenAmountOut).div(tokenAmountIn) : undefined; // TODO: xianny check
+
+        return {
+            id: pool.id,
+            balanceIn: new BigNumber(tToken.balance),
+            balanceOut: new BigNumber(mToken.balance),
+            weightIn: new BigNumber(tToken.weight),
+            weightOut: new BigNumber(mToken.weight),
+            swapFee: new BigNumber(pool.swapFee),
+            spotPrice,
+        };
+    }
+
     constructor(
         private readonly subgraphUrl: string = BALANCER_V2_SUBGRAPH_URL,
         private readonly maxPoolsFetched: number = BALANCER_MAX_POOLS_FETCHED,
+        private readonly _topPoolsFetched: number = BALANCER_TOP_POOLS_FETCHED,
+        private readonly _warningLogger: LogFunction = DEFAULT_WARNING_LOGGER,
         cache: { [key: string]: CacheValue } = {},
     ) {
         super(cache);
+        void this._loadTopPoolsAsync();
+        // Reload the top pools every 12 hours
+        setInterval(async () => void this._loadTopPoolsAsync(), ONE_DAY_MS / 2);
     }
 
     // protected async _fetchPoolsForPairAsync(takerToken: string, makerToken: string): Promise<Pool[]> {
@@ -29,8 +70,74 @@ export class BalancerV2PoolsCache extends PoolsCache {
     //     }
     // }
 
+    protected async _fetchTopPoolsAsync(): Promise<BalancerPoolResponse[]> {
+        const query = gql`
+            query fetchTopPools($topPoolsFetched: Int!) {
+                pools(
+                    first: $topPoolsFetched
+                    where: { totalLiquidity_gt: 0 }
+                    orderBy: swapsCount
+                    orderDirection: desc
+                ) {
+                    id
+                    swapFee
+                    totalWeight
+                    tokensList
+                    amp
+                    totalShares
+                    tokens {
+                        id
+                        address
+                        balance
+                        decimals
+                        symbol
+                        weight
+                    }
+                }
+            }
+        `;
+
+        const { pools } = await request<{ pools: BalancerPoolResponse[] }>(this.subgraphUrl, query, {
+            topPoolsFetched: this._topPoolsFetched,
+        });
+
+        return pools;
+    }
+    protected async _loadTopPoolsAsync(): Promise<void> {
+        const fromToPools: {
+            [from: string]: { [to: string]: Pool[] };
+        } = {};
+
+        const pools = await this._fetchTopPoolsAsync();
+        pools.forEach(pool => {
+            const { tokensList } = pool;
+            for (const from of tokensList) {
+                for (const to of tokensList.filter(t => t.toLowerCase() !== from.toLowerCase())) {
+                    if (!fromToPools[from]) {
+                        fromToPools[from] = {};
+                    }
+                    if (!fromToPools[from][to]) {
+                        fromToPools[from][to] = [];
+                    }
+                    try {
+                        // The list of pools must be relevant to `from` and `to`  for `parsePoolData`
+                        const [poolData] = parsePoolData({ [pool.id]: pool as any }, from, to);
+                        fromToPools[from][to].push(
+                            BalancerV2PoolsCache._parseSubgraphPoolData(poolData[pool.id], from, to),
+                        );
+                        // Cache this as we progress through
+                        const expiresAt = Date.now() + this._cacheTimeMs;
+                        this._cachePoolsForPair(from, to, fromToPools[from][to], expiresAt);
+                    } catch (err) {
+                        this._warningLogger(err, `Failed to load Balancer V2 top pools`);
+                        // soldier on
+                    }
+                }
+            }
+        });
+    }
     protected async _fetchPoolsForPairAsync(takerToken: string, makerToken: string): Promise<Pool[]> {
-        const query = `
+        const query = gql`
         query getPools {
             pools(
               first: ${this.maxPoolsFetched},
@@ -60,25 +167,7 @@ export class BalancerV2PoolsCache extends PoolsCache {
           `;
         try {
             const { pools } = await request(this.subgraphUrl, query);
-            return pools.map((pool: any) => {
-                const tToken = pool.tokens.find((t: any) => t.address === takerToken);
-                const mToken = pool.tokens.find((t: any) => t.address === makerToken);
-                const swap = pool.swaps[0];
-                const tokenAmountOut = swap ? swap.tokenAmountOut : undefined;
-                const tokenAmountIn = swap ? swap.tokenAmountIn : undefined;
-                const spotPrice =
-                    tokenAmountOut && tokenAmountIn ? new BigNumber(tokenAmountOut).div(tokenAmountIn) : undefined; // TODO: xianny check
-
-                return {
-                    id: pool.id,
-                    balanceIn: new BigNumber(tToken.balance),
-                    balanceOut: new BigNumber(mToken.balance),
-                    weightIn: new BigNumber(tToken.weight),
-                    weightOut: new BigNumber(mToken.weight),
-                    swapFee: new BigNumber(pool.swapFee),
-                    spotPrice,
-                };
-            });
+            return pools.map((pool: any) => BalancerV2PoolsCache._parseSubgraphPoolData(pool, takerToken, makerToken));
         } catch (e) {
             return [];
         }

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
@@ -109,16 +109,13 @@ export class BalancerV2PoolsCache extends PoolsCache {
         } = {};
 
         const pools = await this._fetchTopPoolsAsync();
-        pools.forEach(pool => {
+        for (const pool of pools) {
             const { tokensList } = pool;
             for (const from of tokensList) {
                 for (const to of tokensList.filter(t => t.toLowerCase() !== from.toLowerCase())) {
-                    if (!fromToPools[from]) {
-                        fromToPools[from] = {};
-                    }
-                    if (!fromToPools[from][to]) {
-                        fromToPools[from][to] = [];
-                    }
+                    fromToPools[from] = fromToPools[from] || {};
+                    fromToPools[from][to] = fromToPools[from][to] || [];
+
                     try {
                         // The list of pools must be relevant to `from` and `to`  for `parsePoolData`
                         const [poolData] = parsePoolData({ [pool.id]: pool as any }, from, to);
@@ -134,7 +131,7 @@ export class BalancerV2PoolsCache extends PoolsCache {
                     }
                 }
             }
-        });
+        }
     }
     protected async _fetchPoolsForPairAsync(takerToken: string, makerToken: string): Promise<Pool[]> {
         const query = gql`


### PR DESCRIPTION
## Description
This implements a slightly hacky solution to pre-populate the Balancer V2 pool cache on start-up so we avoid having empty a cache the first time we try to sample a token pair. Once Balance releases a new version of SOR that is compatible with both V1 and V2 we can remove the copy-pasta and clean this up 😄 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
