### PR TITLE
AS/Sampler: Tweak compiler settings for smaller sampler size

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.11.0",
+        "changes": [
+            {
+                "note": "Tweak compiler settings for smaller sampler bytecode",
+                "pr": 229
+            }
+        ]
+    },
+    {
         "version": "6.10.0",
         "changes": [
             {

--- a/packages/asset-swapper/compiler.json
+++ b/packages/asset-swapper/compiler.json
@@ -6,7 +6,7 @@
     "shouldSaveStandardInput": true,
     "compilerSettings": {
         "evmVersion": "istanbul",
-        "optimizer": { "enabled": false, "runs": 200, "details": { "yul": true } },
+        "optimizer": { "enabled": true, "runs": 200, "details": { "yul": true, "deduplicate": true } },
         "outputSelection": {
             "*": {
                 "*": [

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -33,7 +33,8 @@
         "generate_contract_wrappers": "abi-gen --debug --abis  ${npm_package_config_abis} --output test/generated-wrappers --backend ethers",
         "contracts:gen": "contracts-gen generate",
         "contracts:copy": "contracts-gen copy",
-        "publish:private": "yarn build && gitpkg publish"
+        "publish:private": "yarn build && gitpkg publish",
+        "sampler-size": "jq .compilerOutput.evm.deployedBytecode.object  -- test/generated-artifacts/ERC20BridgeSampler.json | echo $(( $(wc -c) / 2 - 1 ))"
     },
     "config": {
         "publicInterfaceContracts": "ERC20BridgeSampler,BalanceChecker,FakeTaker",


### PR DESCRIPTION
## Description

We probably care about having a smaller bytecode footprint than being efficient in the sampler since gas is free and we have to pass the full contract to the RPC endpoint for every eth_call.

Prev: ~51KB
Now: ~40KB

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
