### PR TITLE
AS: Less ambiguous EP overhead [TKR-166]

### DIFF
--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -308,7 +308,7 @@ export class SwapQuoter {
             feeSchedule: _.mapValues(fullOpts.feeSchedule, gasCost => (fillData: FillData) =>
                 gasCost === undefined ? 0 : gasPrice.times(gasCost(fillData)),
             ),
-            exchangeProxyOverhead: flags => gasPrice.times(fullOpts.exchangeProxyOverhead(flags)),
+            exchangeProxyOverhead: (...args) => gasPrice.times(fullOpts.exchangeProxyOverhead(...args)),
         };
         // pass the QuoteRequestor on if rfqt enabled
         if (calcOpts.rfqt !== undefined) {
@@ -342,7 +342,10 @@ export class SwapQuoter {
         );
 
         // Use the raw gas, not scaled by gas price
-        const exchangeProxyOverhead = fullOpts.exchangeProxyOverhead(result.sourceFlags).toNumber();
+        const exchangeProxyOverhead = fullOpts.exchangeProxyOverhead(
+            result.sourceFlags,
+            result.numDistinctFills,
+        ).toNumber();
         swapQuote.bestCaseQuoteInfo.gas += exchangeProxyOverhead;
         swapQuote.worstCaseQuoteInfo.gas += exchangeProxyOverhead;
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/comparison_price.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/comparison_price.ts
@@ -50,7 +50,7 @@ export function getComparisonPrices(
             const fillFeeInEth = new BigNumber(
                 (feeSchedule[ERC20BridgeSource.Native] as FeeEstimate)({ type: FillQuoteTransformerOrderType.Rfq }),
             );
-            const exchangeProxyOverheadInEth = new BigNumber(exchangeProxyOverhead(SOURCE_FLAGS.RfqOrder));
+            const exchangeProxyOverheadInEth = new BigNumber(exchangeProxyOverhead(SOURCE_FLAGS.RfqOrder, 1));
             feeInEth = fillFeeInEth.plus(exchangeProxyOverheadInEth);
         } catch {
             logUtils.warn('Native order fee schedule requires fill data');

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -515,6 +515,7 @@ export class MarketOperationUtils {
                 optimizedOrders: twoHopOrders,
                 liquidityDelivered: bestTwoHopQuote,
                 sourceFlags: SOURCE_FLAGS[ERC20BridgeSource.MultiHop],
+                numDistinctFills: 2,
                 marketSideLiquidity,
                 adjustedRate: bestTwoHopRate,
                 unoptimizedPath,
@@ -539,9 +540,9 @@ export class MarketOperationUtils {
             const sturdyFills = fills.filter(p => p.length > 0 && !fragileSources.includes(p[0].source));
             const sturdyOptimalPath = await findOptimalPathAsync(side, sturdyFills, inputAmount, opts.runLimit, {
                 ...penaltyOpts,
-                exchangeProxyOverhead: (sourceFlags: bigint) =>
+                exchangeProxyOverhead: (sourceFlags: bigint, numDistinctFills: number) =>
                     // tslint:disable-next-line: no-bitwise
-                    penaltyOpts.exchangeProxyOverhead(sourceFlags | optimalPath.sourceFlags),
+                    penaltyOpts.exchangeProxyOverhead(sourceFlags | optimalPath.sourceFlags, numDistinctFills),
             });
             // Calculate the slippage of on-chain sources compared to the most optimal path
             // if within an acceptable threshold we enable a fallback to prevent reverts
@@ -559,6 +560,7 @@ export class MarketOperationUtils {
             optimizedOrders: collapsedPath.orders,
             liquidityDelivered: collapsedPath.collapsedFills as CollapsedFill[],
             sourceFlags: collapsedPath.sourceFlags,
+            numDistinctFills: collapsedPath.numDistinctFills,
             marketSideLiquidity,
             adjustedRate: optimalPathRate,
             unoptimizedPath,

--- a/packages/asset-swapper/src/utils/market_operation_utils/path.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path.ts
@@ -292,6 +292,7 @@ export class Path {
     private _addFill(fill: Fill): void {
         this._fillsById[fill.sourcePathId] = this._fillsById[fill.sourcePathId] || [];
         this._fillsById[fill.sourcePathId].push(fill);
+        this._numDistinctFills = Object.keys(this._fillsById).length;
         if (this._size.input.plus(fill.input).isGreaterThan(this.targetInput)) {
             const remainingInput = this.targetInput.minus(this._size.input);
             const scaledFillOutput = fill.output.times(remainingInput.div(fill.input));

--- a/packages/asset-swapper/src/utils/market_operation_utils/rate_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/rate_utils.ts
@@ -30,6 +30,7 @@ export function getTwoHopAdjustedRate(
             SOURCE_FLAGS.MultiHop |
                 SOURCE_FLAGS[fillData.firstHop.source] |
                 SOURCE_FLAGS[fillData.secondHop.source],
+            2,
         ).plus(fees[ERC20BridgeSource.MultiHop]!(fillData)),
     );
     const adjustedOutput = side === MarketOperation.Sell ? output.minus(penalty) : output.plus(penalty);

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -147,7 +147,7 @@ export interface GetMarketOrdersRfqOpts extends RfqRequestOpts {
 
 export type FeeEstimate = (fillData: FillData) => number | BigNumber;
 export type FeeSchedule = Partial<{ [key in ERC20BridgeSource]: FeeEstimate }>;
-export type ExchangeProxyOverhead = (sourceFlags: bigint) => BigNumber;
+export type ExchangeProxyOverhead = (sourceFlags: bigint, numDistinctFills: number) => BigNumber;
 
 /**
  * Options for `getMarketSellOrdersAsync()` and `getMarketBuyOrdersAsync()`.
@@ -236,6 +236,7 @@ export interface GetMarketOrdersOpts {
 export interface OptimizerResult {
     optimizedOrders: OptimizedMarketOrder[];
     sourceFlags: bigint;
+    numDistinctFills: number;
     liquidityDelivered: CollapsedFill[] | DexSample<TwoHopFillData>;
     marketSideLiquidity: MarketSideLiquidity;
     adjustedRate: BigNumber;


### PR DESCRIPTION
TKR-166

## Description

Adds a new parameter to `ExchangeProxyOverhead`: `exchangeProxyOverhead(sourceFlags: bigint, numDistinctFills: number)`, where `numDistinctFills` is the number of unique `fill.sourcePathId`s in a `Path`.

Previously if we had a DAI->USDT multi-hop path like:
```
UniswapV3(DAI->WETH->USDC) -> UniswapV3(USDC->WETH->USDT)
```
the source flags would look like `SOURCE_FLAGS[UniswapV3] | SOURCE_FLAGS[UniswapV3] == SOURCE_FLAGS[UniswapV3]` which would trigger the (cheaper) EP overhead for UniswapV3 VIP even though this is not VIP compatible (there are two distinct uniswap V3 fills).

Now `exchangeProxyOverhead()` in API looks like:
```ts
    exchangeProxyOverhead: (sourceFlags, numDistinctFills) => {
        if (numDistinctFills === 1) {
            // VIPs only support one "fill". Multi-hop uniswap paths are considered
            // a single "fill" to the router.
            if ([SOURCE_FLAGS.Uniswap_V2, SOURCE_FLAGS.SushiSwap].includes(sourceFlags)) {
                // Uniswap and forks VIP
                return TX_BASE_GAS;
            } else if (
                [
                    SOURCE_FLAGS.SushiSwap,
                    SOURCE_FLAGS.PancakeSwap,
                    SOURCE_FLAGS.PancakeSwap_V2,
                    SOURCE_FLAGS.BakerySwap,
                    SOURCE_FLAGS.ApeSwap,
                    SOURCE_FLAGS.CafeSwap,
                    SOURCE_FLAGS.CheeseSwap,
                    SOURCE_FLAGS.JulSwap,
                ].includes(sourceFlags) &&
                CHAIN_ID === ChainId.BSC
            ) {
                // PancakeSwap and forks VIP
                return TX_BASE_GAS;
            } else if (SOURCE_FLAGS.Uniswap_V3 === sourceFlags) {
                // Uniswap V3 VIP
                return TX_BASE_GAS.plus(5e3);
            } else if (numDistinctFills === 1 && SOURCE_FLAGS.Curve === sourceFlags) {
                // Curve pseudo-VIP
                return TX_BASE_GAS.plus(40e3);
            } else if (SOURCE_FLAGS.LiquidityProvider === sourceFlags) {
                // PLP VIP
                return TX_BASE_GAS.plus(10e3);
            }
        }
        if ((MULTIPLEX_BATCH_FILL_SOURCE_FLAGS | sourceFlags) === MULTIPLEX_BATCH_FILL_SOURCE_FLAGS) {
            // Multiplex batch fill
            return TX_BASE_GAS.plus(15e3);
        } else if (
            (MULTIPLEX_MULTIHOP_FILL_SOURCE_FLAGS | sourceFlags) ===
            (MULTIPLEX_MULTIHOP_FILL_SOURCE_FLAGS | SOURCE_FLAGS.MultiHop)
        ) {
            // Multiplex multi-hop fill
            return TX_BASE_GAS.plus(25e3);
        } else {
            return FILL_QUOTE_TRANSFORMER_GAS_OVERHEAD;
        }
    },
```

Simbot example:
```
SELL ETH->SHIB 7.89 -> 1883834292.73 ($17555.18) after 68.7s @ prod
	✔ PASS 7.89 -> 1877412595.65 ($5611.25) ($20.99)
	MultiHop: 100%
	Uniswap_V3, Uniswap_V3, intermediateToken: 0xdac17f958d2ee523a2206206994597c13d831ec7}
	gas: 629041
SELL ETH->SHIB 7.89 -> 1881468660.48 ($17555.18) after 68.7s @ dev
	✔ PASS 7.89 -> 1881259386.89 ($5639.66) ($4.12)
	Uniswap_V3: 100%
	gas: 123477
````

https://metabase.spaceship.0x.org/dashboard/186?run_id=confuse-fluttering-trucks&adjusted_amount_bought_win_tolerance__bps_=0.5

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
