### PR TITLE
AS: Fix fill amount rounding error when converting to orders

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "16.23.1",
+        "changes": [
+            {
+                "note": "Fix fill amount rounding error when covnerting fills to orders.",
+                "pr": 296
+            }
+        ]
+    },
+    {
         "version": "16.23.0",
         "changes": [
             {

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -480,9 +480,9 @@ export const BRIDGE_ENCODERS: {
 function getFillTokenAmounts(fill: CollapsedFill, side: MarketOperation): [BigNumber, BigNumber] {
     return [
         // Maker asset amount.
-        side === MarketOperation.Sell ? fill.output : fill.input,
+        side === MarketOperation.Sell ? fill.output.integerValue(BigNumber.ROUND_DOWN) : fill.input,
         // Taker asset amount.
-        side === MarketOperation.Sell ? fill.input : fill.output,
+        side === MarketOperation.Sell ? fill.input : fill.output.integerValue(BigNumber.ROUND_UP),
     ];
 }
 


### PR DESCRIPTION
## Description
Paths don't often produce integer `output` values. Previously we were using this value directly to populate the `maxTakerFillAmount` in an FQT order. But for buys this can sometimes result in selling too little and causing an underbought error. This PR rounds up or down the path values to prevent this issue.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
