### PR TITLE
fix: Add ethers dependency to `0x/contracts-erc20`

### DIFF
--- a/contracts/erc20/CHANGELOG.json
+++ b/contracts/erc20/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.3.15",
+        "changes": [
+            {
+                "note": "Add ethers as a dependency",
+                "pr": 305
+            }
+        ]
+    },
+    {
         "timestamp": 1628225642,
         "version": "3.3.14",
         "changes": [

--- a/contracts/erc20/package.json
+++ b/contracts/erc20/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/contracts-erc20",
-    "version": "3.3.14",
+    "version": "3.3.15",
     "engines": {
         "node": ">=6.12"
     },
@@ -82,7 +82,8 @@
         "typescript": "4.2.2"
     },
     "dependencies": {
-        "@0x/base-contract": "^6.4.0"
+        "@0x/base-contract": "^6.4.0",
+        "ethers": "~4.0.4"
     },
     "publishConfig": {
         "access": "public"

--- a/contracts/erc20/package.json
+++ b/contracts/erc20/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/contracts-erc20",
-    "version": "3.3.15",
+    "version": "3.3.14",
     "engines": {
         "node": ">=6.12"
     },


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Here's the problem: `0x/abi-gen`, which is used to build the contracts in `0x/contracts-erc20`, produces code specific to `ethers` v4. [An example from the TS template:](https://github.com/0xProject/tools/blob/5d17d8f4581e6a9f066d51530910e9b708cde661/abi-gen/templates/TypeScript/contract.handlebars#L151)

```
const iface = new ethers.utils.Interface(abi);
const deployInfo = iface.deployFunction;
const txData = deployInfo.encode(bytecode, [{{> params inputs=ctor.inputs}}]);
```

`deployFunction` is present in [ethers v4](https://docs.ethers.io/v4/api-advanced.html#id3), but v5 breaks this.

`ethers` is currently not a dependency of `@0x/contracts-erc20`. Therefore, if a package depends on `@0x/contracts-erc20`, to resolve `ethers` node will look in `@0x/contracts-erc20`'s `node_modules` and not find it, and node will [start traversing up the file tree to find `ethers`](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders). If the package depending on `@0x/contracts-erc20` also depends on `ethers` v5, then that version of `ethers` will be used to process the generated contract abi. Since `deployFunction` is `undefined` in v5, the program will fail when it tries to access `deployInfo.encode`.


Add `ethers` v4 as an explicit dependency of `@0x/contracts-erc20` so that contracts will always require v4.
## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
