### PR TITLE
Fix ApproximateBuys

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "16.27.1",
+        "changes": [
+            {
+                "note": "Fix ApproximateBuys sampler to terminate if the buy amount is not met",
+                "pr": 319
+            }
+        ]
+    },
+    {
         "version": "16.27.0",
         "changes": [
             {

--- a/packages/asset-swapper/contracts/src/ApproximateBuys.sol
+++ b/packages/asset-swapper/contracts/src/ApproximateBuys.sol
@@ -77,6 +77,7 @@ contract ApproximateBuys {
         }
 
         for (uint256 i = 0; i < makerTokenAmounts.length; i++) {
+            uint256 eps = 0;
             for (uint256 iter = 0; iter < APPROXIMATE_BUY_MAX_ITERATIONS; iter++) {
                 // adjustedSellAmount = previousSellAmount * (target/actual) * JUMP_MULTIPLIER
                 sellAmount = _safeGetPartialAmountCeil(
@@ -108,13 +109,16 @@ contract ApproximateBuys {
                 buyAmount = _buyAmount;
                 // If we've reached our goal, exit early
                 if (buyAmount >= makerTokenAmounts[i]) {
-                    uint256 eps =
+                    eps =
                         (buyAmount - makerTokenAmounts[i]) * ONE_HUNDED_PERCENT_BPS /
                         makerTokenAmounts[i];
                     if (eps <= APPROXIMATE_BUY_TARGET_EPSILON_BPS) {
                         break;
                     }
                 }
+            }
+            if (eps == 0 || eps > APPROXIMATE_BUY_TARGET_EPSILON_BPS) {
+                break;
             }
             // We do our best to close in on the requested amount, but we can either over buy or under buy and exit
             // if we hit a max iteration limit


### PR DESCRIPTION
## Description

In the `ApproximateBuys` ERC20BridgeSampler mixin we never really checked if we were actually hitting the requested buy amount when we loop to find the sell amount. The mooniswap USDT/DAI pool has only $180 in it so we saw a really great rate when trying to buy $300 because we were being quoted a really low sell amount for $300 without checking that we were actually buying $300 (which is impossible).  
  
For `swap/v1/quote?sellToken=DAI&buyToken=USDT&buyAmount=300000000`:
Before: `"price": "0.005448990721247178"`
After: `"price": "1.002948123432271921"`

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
