### PR TITLE
fix: Refactor integrator ID and add Prometheus metrics

### DIFF
--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -50,7 +50,7 @@ const DEFAULT_SWAP_QUOTER_OPTS: SwapQuoterOpts = {
     samplerGasLimit: 500e6,
     ethGasStationUrl: ETH_GAS_STATION_API_URL,
     rfqt: {
-        takerApiKeyWhitelist: [],
+        integratorsWhitelist: [],
         makerAssetOfferings: {},
         txOriginBlacklist: new Set(),
     },

--- a/packages/asset-swapper/src/index.ts
+++ b/packages/asset-swapper/src/index.ts
@@ -88,6 +88,7 @@ export {
     ExchangeProxyContractOpts,
     ExchangeProxyRefundReceiver,
     GetExtensionContractTypeOpts,
+    Integrator,
     LogFunction,
     MarketBuySwapQuote,
     MarketOperation,

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -449,7 +449,7 @@ export class SwapQuoter {
         }
 
         // If an integrator ID was provided, but the ID is not whitelisted, raise a warning and disable RFQ
-        if (!this._isIntegrationKeyWhitelisted(integrator.integratorId)) {
+        if (!this._isIntegratorIdWhitelisted(integrator.integratorId)) {
             if (this._rfqtOptions && this._rfqtOptions.warningLogger) {
                 this._rfqtOptions.warningLogger(
                     {

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -448,7 +448,7 @@ export class SwapQuoter {
             throw new Error('Native liquidity cannot be excluded if "rfqt.nativeExclusivelyRFQ" is set');
         }
 
-        // If an API key was provided, but the key is not whitelisted, raise a warning and disable RFQ
+        // If an integrator ID was provided, but the ID is not whitelisted, raise a warning and disable RFQ
         if (!this._isIntegrationKeyWhitelisted(integrator.integratorId)) {
             if (this._rfqtOptions && this._rfqtOptions.warningLogger) {
                 this._rfqtOptions.warningLogger(

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -419,10 +419,10 @@ export class SwapQuoter {
     }; // tslint:disable-line:semicolon
 
     private _isIntegratorIdWhitelisted(integratorId: string | undefined): boolean {
-        if (!apiKey) {
+        if (!integratorId) {
             return false;
         }
-        return this._integratorIdsSet.has(apiKey);
+        return this._integratorIdsSet.has(integratorId);
     }
 
     private _isTxOriginBlacklisted(txOrigin: string | undefined): boolean {
@@ -477,7 +477,7 @@ export class SwapQuoter {
         // Otherwise check other RFQ options
         if (
             intentOnFilling && // The requestor is asking for a firm quote
-            this._isIntegrationKeyWhitelisted(integrator.integratorId) && // A valid API key was provided
+            this._isIntegratorIdWhitelisted(integrator.integratorId) && // A valid API key was provided
             sourceFilters.isAllowed(ERC20BridgeSource.Native) // Native liquidity is not excluded
         ) {
             if (!txOrigin || txOrigin === constants.NULL_ADDRESS) {

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -75,6 +75,7 @@ export class SwapQuoter {
     private readonly _marketOperationUtils: MarketOperationUtils;
     private readonly _rfqtOptions?: SwapQuoterRfqOpts;
     private readonly _quoteRequestorHttpClient: AxiosInstance;
+    private readonly _integratorIdsSet: Set<string>;
 
     /**
      * Instantiates a new SwapQuoter instance
@@ -164,6 +165,9 @@ export class SwapQuoter {
             httpsAgent: new HttpsAgent({ keepAlive: true, timeout: KEEP_ALIVE_TTL }),
             ...(rfqt ? rfqt.axiosInstanceOpts : {}),
         });
+
+        const integratorIds = this._rfqtOptions?.integratorsWhitelist.map(integrator => integrator.integratorId) || [];
+        this._integratorIdsSet = new Set(integratorIds);
     }
 
     public async getBatchMarketBuySwapQuoteAsync(
@@ -414,12 +418,11 @@ export class SwapQuoter {
         return isOpenOrder && !willOrderExpire && isFeeTypeAllowed;
     }; // tslint:disable-line:semicolon
 
-    private _isApiKeyWhitelisted(apiKey: string | undefined): boolean {
+    private _isIntegrationKeyWhitelisted(apiKey: string | undefined): boolean {
         if (!apiKey) {
             return false;
         }
-        const whitelistedApiKeys = this._rfqtOptions ? this._rfqtOptions.takerApiKeyWhitelist : [];
-        return whitelistedApiKeys.includes(apiKey);
+        return this._integratorIdsSet.has(apiKey);
     }
 
     private _isTxOriginBlacklisted(txOrigin: string | undefined): boolean {
@@ -438,7 +441,7 @@ export class SwapQuoter {
             return rfqt;
         }
         // tslint:disable-next-line: boolean-naming
-        const { apiKey, nativeExclusivelyRFQ, intentOnFilling, txOrigin } = rfqt;
+        const { integrator, nativeExclusivelyRFQ, intentOnFilling, txOrigin } = rfqt;
         // If RFQ-T is enabled and `nativeExclusivelyRFQ` is set, then `ERC20BridgeSource.Native` should
         // never be excluded.
         if (nativeExclusivelyRFQ === true && !sourceFilters.isAllowed(ERC20BridgeSource.Native)) {
@@ -446,11 +449,11 @@ export class SwapQuoter {
         }
 
         // If an API key was provided, but the key is not whitelisted, raise a warning and disable RFQ
-        if (!this._isApiKeyWhitelisted(apiKey)) {
+        if (!this._isIntegrationKeyWhitelisted(integrator.integratorId)) {
             if (this._rfqtOptions && this._rfqtOptions.warningLogger) {
                 this._rfqtOptions.warningLogger(
                     {
-                        apiKey,
+                        ...integrator,
                     },
                     'Attempt at using an RFQ API key that is not whitelisted. Disabling RFQ for the request lifetime.',
                 );
@@ -474,7 +477,7 @@ export class SwapQuoter {
         // Otherwise check other RFQ options
         if (
             intentOnFilling && // The requestor is asking for a firm quote
-            this._isApiKeyWhitelisted(apiKey) && // A valid API key was provided
+            this._isIntegrationKeyWhitelisted(integrator.integratorId) && // A valid API key was provided
             sourceFilters.isAllowed(ERC20BridgeSource.Native) // Native liquidity is not excluded
         ) {
             if (!txOrigin || txOrigin === constants.NULL_ADDRESS) {

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -418,7 +418,7 @@ export class SwapQuoter {
         return isOpenOrder && !willOrderExpire && isFeeTypeAllowed;
     }; // tslint:disable-line:semicolon
 
-    private _isIntegrationKeyWhitelisted(apiKey: string | undefined): boolean {
+    private _isIntegratorIdWhitelisted(integratorId: string | undefined): boolean {
         if (!apiKey) {
             return false;
         }

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -243,7 +243,7 @@ export interface RfqmRequestOptions extends RfqRequestOpts {
 export interface RfqRequestOpts {
     takerAddress: string;
     txOrigin: string;
-    apiKey: string;
+    integrator: Integrator
     apiKeyWhitelist?: string[];
     intentOnFilling: boolean;
     isIndicative?: boolean;
@@ -294,8 +294,13 @@ export interface RfqFirmQuoteValidator {
     getRfqtTakerFillableAmountsAsync(quotes: RfqOrder[]): Promise<BigNumber[]>;
 }
 
+export interface Integrator {
+    integratorId: string;
+    label: string;
+}
+
 export interface SwapQuoterRfqOpts {
-    takerApiKeyWhitelist: string[];
+    integratorsWhitelist: Integrator[]
     makerAssetOfferings: RfqMakerAssetOfferings;
     txOriginBlacklist: Set<string>;
     altRfqCreds?: {

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -243,7 +243,7 @@ export interface RfqmRequestOptions extends RfqRequestOpts {
 export interface RfqRequestOpts {
     takerAddress: string;
     txOrigin: string;
-    integrator: Integrator
+    integrator: Integrator;
     apiKeyWhitelist?: string[];
     intentOnFilling: boolean;
     isIndicative?: boolean;
@@ -300,7 +300,7 @@ export interface Integrator {
 }
 
 export interface SwapQuoterRfqOpts {
-    integratorsWhitelist: Integrator[]
+    integratorsWhitelist: Integrator[];
     makerAssetOfferings: RfqMakerAssetOfferings;
     txOriginBlacklist: Set<string>;
     altRfqCreds?: {

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -65,8 +65,8 @@ export interface MetricsProxy {
 
     /**
      * Logs the outcome of a network (HTTP) interaction with a market maker.
-     * 
-     * @param interaction.isLastLook true if the request is RFQM 
+     *
+     * @param interaction.isLastLook true if the request is RFQM
      * @param interaction.integrator the integrator that is requesting the RFQ quote
      * @param interaction.url the URL of the market maker
      * @param interaction.quoteType indicative or firm quote
@@ -77,10 +77,10 @@ export interface MetricsProxy {
      *                             means that the network response was successful.
      */
     logRfqMakerNetworkInteraction(interaction: {
-        isLastLook: boolean,
+        isLastLook: boolean;
         integrator: Integrator;
         url: string;
-        quoteType: 'firm' | 'indicative' 
+        quoteType: 'firm' | 'indicative';
         statusCode: number | undefined;
         latencyMs: number;
         included: boolean;
@@ -479,8 +479,8 @@ export class QuoteRequestor {
             // filter out requests to skip
             const isBlacklisted = rfqMakerBlacklist.isMakerBlacklisted(typedMakerUrl.url);
             const partialLogEntry = { url: typedMakerUrl.url, quoteType, requestParams, isBlacklisted };
-            const {isLastLook, integrator} = options;
-            const {sellTokenAddress, buyTokenAddress} = requestParams;
+            const { isLastLook, integrator } = options;
+            const { sellTokenAddress, buyTokenAddress } = requestParams;
             if (isBlacklisted) {
                 this._metrics?.logRfqMakerNetworkInteraction({
                     isLastLook: false,
@@ -621,7 +621,7 @@ export class QuoteRequestor {
                     rfqMakerBlacklist.logTimeoutOrLackThereof(typedMakerUrl.url, latencyMs >= timeoutMs);
                     this._warningLogger(
                         convertIfAxiosError(err),
-                        `Failed to get RFQ-T ${quoteType} quote from market maker endpoint ${typedMakerUrl.url} for integrator ${options.integrator.integratorId} (${options.integrator.label}) for taker address ${options.takerAddress} and tx origin ${options.txOrigin}`
+                        `Failed to get RFQ-T ${quoteType} quote from market maker endpoint ${typedMakerUrl.url} for integrator ${options.integrator.integratorId} (${options.integrator.label}) for taker address ${options.takerAddress} and tx origin ${options.txOrigin}`,
                     );
                     return;
                 }

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -64,16 +64,19 @@ export interface MetricsProxy {
     incrementFillRatioWarningCounter(isLastLook: boolean, maker: string): void;
 
     /**
-     * Logs the outcome of an interaction with a market maker
+     * Logs the outcome of a network (HTTP) interaction with a market maker.
+     * 
      * @param interaction.isLastLook true if the request is RFQM 
      * @param interaction.integrator the integrator that is requesting the RFQ quote
      * @param interaction.url the URL of the market maker
      * @param interaction.quoteType indicative or firm quote
      * @param interaction.statusCode the statusCode returned by a market maker
      * @param interaction.latencyMs the latency of the HTTP request (in ms)
-     * @param interaction.included if a firm quote that was returned got included in the order salad
+     * @param interaction.included if a firm quote that was returned got included in the next step of processing.
+     *                             NOTE: this does not mean that the request returned a valid fillable order. It just
+     *                             means that the network response was successful.
      */
-    logRfqMakerInteraction(interaction: {
+    logRfqMakerNetworkInteraction(interaction: {
         isLastLook: boolean,
         integrator: Integrator;
         url: string;
@@ -479,7 +482,7 @@ export class QuoteRequestor {
             const {isLastLook, integrator} = options;
             const {sellTokenAddress, buyTokenAddress} = requestParams;
             if (isBlacklisted) {
-                this._metrics?.logRfqMakerInteraction({
+                this._metrics?.logRfqMakerNetworkInteraction({
                     isLastLook: false,
                     url: typedMakerUrl.url,
                     quoteType,
@@ -514,7 +517,7 @@ export class QuoteRequestor {
                             cancelToken: cancelTokenSource.token,
                         });
                         const latencyMs = Date.now() - timeBeforeAwait;
-                        this._metrics?.logRfqMakerInteraction({
+                        this._metrics?.logRfqMakerNetworkInteraction({
                             isLastLook: isLastLook || false,
                             url: typedMakerUrl.url,
                             quoteType,
@@ -561,7 +564,7 @@ export class QuoteRequestor {
                         );
 
                         const latencyMs = Date.now() - timeBeforeAwait;
-                        this._metrics?.logRfqMakerInteraction({
+                        this._metrics?.logRfqMakerNetworkInteraction({
                             isLastLook: isLastLook || false,
                             url: typedMakerUrl.url,
                             quoteType,
@@ -591,7 +594,7 @@ export class QuoteRequestor {
                 } catch (err) {
                     // log error if any
                     const latencyMs = Date.now() - timeBeforeAwait;
-                    this._metrics?.logRfqMakerInteraction({
+                    this._metrics?.logRfqMakerNetworkInteraction({
                         isLastLook: isLastLook || false,
                         url: typedMakerUrl.url,
                         quoteType,

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -511,7 +511,10 @@ export class QuoteRequestor {
                 try {
                     if (typedMakerUrl.pairType === RfqPairType.Standard) {
                         const response = await this._quoteRequestorHttpClient.get(`${typedMakerUrl.url}/${quotePath}`, {
-                            headers: { '0x-api-key': options.integrator.integratorId },
+                            headers: {
+                                '0x-api-key': options.integrator.integratorId,
+                                '0x-integrator-id': options.integrator.integratorId,
+                            },
                             params: requestParams,
                             timeout: timeoutMs,
                             cancelToken: cancelTokenSource.token,

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -14,6 +14,7 @@ import { constants } from '../constants';
 import {
     AltQuoteModel,
     AltRfqMakerAssetOfferings,
+    Integrator,
     LogFunction,
     MarketOperation,
     RfqMakerAssetOfferings,
@@ -62,16 +63,22 @@ export interface MetricsProxy {
      */
     incrementFillRatioWarningCounter(isLastLook: boolean, maker: string): void;
 
-
+    /**
+     * Logs the outcome of an interaction with a market maker
+     * @param interaction.isLastLook true if the request is RFQM 
+     * @param interaction.integrator the integrator that is requesting the RFQ quote
+     * @param interaction.url the URL of the market maker
+     * @param interaction.quoteType indicative or firm quote
+     * @param interaction.statusCode the statusCode returned by a market maker
+     * @param interaction.latencyMs the latency of the HTTP request (in ms)
+     * @param interaction.included if a firm quote that was returned got included in the order salad
+     */
     logRfqMakerInteraction(interaction: {
         isLastLook: boolean,
-        integrator: {
-            integratorId: string;
-            label: string;
-        };
+        integrator: Integrator;
         url: string;
-        quoteType: 'firm' | 'indicative'; 
-        statusCode: number;
+        quoteType: 'firm' | 'indicative' 
+        statusCode: number | undefined;
         latencyMs: number;
         included: boolean;
     }): void;

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -16,7 +16,7 @@ import * as _ from 'lodash';
 import * as TypeMoq from 'typemoq';
 
 import { MarketOperation, QuoteRequestor, RfqRequestOpts, SignedNativeOrder } from '../src';
-import { NativeOrderWithFillableAmounts } from '../src/types';
+import { Integrator, NativeOrderWithFillableAmounts } from '../src/types';
 import { MarketOperationUtils } from '../src/utils/market_operation_utils/';
 import {
     BUY_SOURCE_FILTER_BY_CHAIN_ID,
@@ -62,6 +62,10 @@ const SELL_SOURCES = SELL_SOURCE_FILTER_BY_CHAIN_ID[ChainId.Mainnet].sources;
 const TOKEN_ADJACENCY_GRAPH: TokenAdjacencyGraph = { default: [] };
 
 const SIGNATURE = { v: 1, r: NULL_BYTES, s: NULL_BYTES, signatureType: SignatureType.EthSign };
+const FOO_INTEGRATOR: Integrator = {
+    integratorId: 'foo',
+    label: 'foo',
+};
 
 /**
  * gets the orders required for a market sell operation by (potentially) merging native orders with
@@ -745,7 +749,7 @@ describe('MarketOperationUtils tests', () => {
                         feeSchedule,
                         rfqt: {
                             isIndicative: false,
-                            apiKey: 'foo',
+                            integrator: FOO_INTEGRATOR,
                             takerAddress: randomAddress(),
                             txOrigin: randomAddress(),
                             intentOnFilling: true,
@@ -790,7 +794,7 @@ describe('MarketOperationUtils tests', () => {
                         ...DEFAULT_OPTS,
                         rfqt: {
                             isIndicative: false,
-                            apiKey: 'foo',
+                            integrator: FOO_INTEGRATOR,
                             takerAddress: randomAddress(),
                             intentOnFilling: true,
                             txOrigin: randomAddress(),
@@ -837,7 +841,7 @@ describe('MarketOperationUtils tests', () => {
                         ...DEFAULT_OPTS,
                         rfqt: {
                             isIndicative: true,
-                            apiKey: 'foo',
+                            integrator: FOO_INTEGRATOR,
                             takerAddress: randomAddress(),
                             txOrigin: randomAddress(),
                             intentOnFilling: true,
@@ -896,7 +900,10 @@ describe('MarketOperationUtils tests', () => {
                         ...DEFAULT_OPTS,
                         rfqt: {
                             isIndicative: false,
-                            apiKey: 'foo',
+                            integrator: {
+                                integratorId: 'foo',
+                                label: 'foo',
+                            },
                             takerAddress: randomAddress(),
                             intentOnFilling: true,
                             txOrigin: randomAddress(),
@@ -954,7 +961,7 @@ describe('MarketOperationUtils tests', () => {
                         ...DEFAULT_OPTS,
                         rfqt: {
                             isIndicative: false,
-                            apiKey: 'foo',
+                            integrator: FOO_INTEGRATOR,
                             takerAddress: randomAddress(),
                             txOrigin: randomAddress(),
                             intentOnFilling: true,

--- a/packages/asset-swapper/test/quote_requestor_test.ts
+++ b/packages/asset-swapper/test/quote_requestor_test.ts
@@ -240,7 +240,10 @@ describe('QuoteRequestor', async () => {
                         MarketOperation.Sell,
                         undefined,
                         {
-                            apiKey,
+                            integrator: {
+                                integratorId: apiKey,
+                                label: 'foo',
+                            },
                             takerAddress,
                             txOrigin: takerAddress,
                             intentOnFilling: true,
@@ -435,7 +438,10 @@ describe('QuoteRequestor', async () => {
                         MarketOperation.Sell,
                         undefined,
                         {
-                            apiKey,
+                            integrator: {
+                                integratorId: apiKey,
+                                label: 'foo',
+                            },
                             takerAddress,
                             txOrigin: takerAddress,
                             intentOnFilling: true,
@@ -551,7 +557,10 @@ describe('QuoteRequestor', async () => {
                         MarketOperation.Sell,
                         undefined,
                         {
-                            apiKey,
+                            integrator: {
+                                integratorId: apiKey,
+                                label: 'foo',
+                            },
                             takerAddress,
                             txOrigin: takerAddress,
                             intentOnFilling: true,
@@ -675,7 +684,10 @@ describe('QuoteRequestor', async () => {
                         MarketOperation.Sell,
                         undefined,
                         {
-                            apiKey,
+                            integrator: {
+                                integratorId: apiKey,
+                                label: 'foo',
+                            },
                             takerAddress,
                             txOrigin: takerAddress,
                             intentOnFilling: true,
@@ -762,7 +774,10 @@ describe('QuoteRequestor', async () => {
                         MarketOperation.Sell,
                         undefined,
                         {
-                            apiKey,
+                            integrator: {
+                                integratorId: apiKey,
+                                label: 'foo',
+                            },
                             takerAddress,
                             txOrigin: takerAddress,
                             intentOnFilling: true,
@@ -823,7 +838,10 @@ describe('QuoteRequestor', async () => {
                         MarketOperation.Buy,
                         undefined,
                         {
-                            apiKey,
+                            integrator: {
+                                integratorId: apiKey,
+                                label: 'foo',
+                            },
                             takerAddress,
                             txOrigin: takerAddress,
                             intentOnFilling: true,
@@ -1088,7 +1106,10 @@ describe('QuoteRequestor', async () => {
                             altScenario.requestedOperation,
                             undefined,
                             {
-                                apiKey,
+                                integrator: {
+                                    integratorId: apiKey,
+                                    label: 'foo',
+                                },
                                 takerAddress,
                                 txOrigin,
                                 intentOnFilling: true,

--- a/packages/asset-swapper/test/utils/test_helpers.ts
+++ b/packages/asset-swapper/test/utils/test_helpers.ts
@@ -48,7 +48,11 @@ export const testHelpers = {
             // Mock out Standard RFQ-T/M responses
             for (const mockedResponse of standardMockedResponses) {
                 const { endpoint, requestApiKey, requestParams, responseData, responseCode } = mockedResponse;
-                const requestHeaders = { Accept: 'application/json, text/plain, */*', '0x-api-key': requestApiKey };
+                const requestHeaders = {
+                    Accept: 'application/json, text/plain, */*',
+                    '0x-api-key': requestApiKey,
+                    '0x-integrator-id': requestApiKey,
+                };
                 if (mockedResponse.callback !== undefined) {
                     mockedAxios
                         .onGet(`${endpoint}/${quoteType}`, { params: requestParams }, requestHeaders)


### PR DESCRIPTION
1. Adds more Prometheus counters in the networking layer of HTTP(s) requests towards market makers
2. Adds a little more documentation and structure in the type formatting
3. Changes naming from `apiKey` to `integrator`