### PR TITLE
fix(docs): pin Sphinx version to 3.x to generate CSS

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 six
+sphinx==3.5.4
 sphinx-markdown-tables


### PR DESCRIPTION
## Description

Custom CSS seems to [have broken in Sphinx 4](https://github.com/sphinx-doc/sphinx/issues/2442).
Guessing readthedocs.io or their package repository upgraded the default
version of Sphinx to 4 and that caused our builds to start breaking.

They [recommend pinning dependencies](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies), let's do that here for Sphinx!

## Testing instructions

Check https://protocol.0x.org/en/fix-docs-css/, which is built from this branch!

## Types of changes

Documentation

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
