### PR TITLE
Fix ABI encoding error with two hop buys

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "16.49.2",
+        "changes": [
+            {
+                "note": "Fix ABI encoding error with two hop buys due to applying slippage to uint(-1) values",
+                "pr": 410
+            }
+        ]
+    },
+    {
         "version": "16.49.1",
         "changes": [
             {

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -701,8 +701,16 @@ function slipNonNativeOrders(quote: MarketSellSwapQuote | MarketBuySwapQuote): O
         return {
             ...o,
             ...(quote.type === MarketOperation.Sell
-                ? { makerAmount: o.makerAmount.times(1 - slippage).integerValue(BigNumber.ROUND_DOWN) }
-                : { takerAmount: o.takerAmount.times(1 + slippage).integerValue(BigNumber.ROUND_UP) }),
+                ? {
+                      makerAmount: o.makerAmount.eq(MAX_UINT256)
+                          ? MAX_UINT256
+                          : o.makerAmount.times(1 - slippage).integerValue(BigNumber.ROUND_DOWN),
+                  }
+                : {
+                      takerAmount: o.takerAmount.eq(MAX_UINT256)
+                          ? MAX_UINT256
+                          : o.takerAmount.times(1 + slippage).integerValue(BigNumber.ROUND_UP),
+                  }),
         };
     });
 }


### PR DESCRIPTION
## Description

Multihop orders use `uint256(-1)` as intermediate amounts. We should not be applying slippage to those values in the consumer.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
