### PR TITLE
fix: slippage inconsistency when recalculated in exchange proxy quote consumer

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "16.49.3",
+        "changes": [
+            {
+                "note": "Fix `slippage` inconsistency when recalculated in exchange proxy quote consumer",
+                "pr": 412
+            }
+        ]
+    },
+    {
         "version": "16.49.2",
         "changes": [
             {

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -691,7 +691,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
 
 function slipNonNativeOrders(quote: MarketSellSwapQuote | MarketBuySwapQuote): OptimizedMarketOrder[] {
     const slippage = getMaxQuoteSlippageRate(quote);
-    if (!slippage) {
+    if (slippage === 0) {
         return quote.orders;
     }
     return quote.orders.map(o => {
@@ -716,18 +716,5 @@ function slipNonNativeOrders(quote: MarketSellSwapQuote | MarketBuySwapQuote): O
 }
 
 function getMaxQuoteSlippageRate(quote: MarketBuySwapQuote | MarketSellSwapQuote): number {
-    if (quote.type === MarketOperation.Buy) {
-        // (worstCaseTaker - bestCaseTaker) / bestCaseTaker
-        // where worstCaseTaker >= bestCaseTaker
-        return quote.worstCaseQuoteInfo.takerAmount
-            .minus(quote.bestCaseQuoteInfo.takerAmount)
-            .div(quote.bestCaseQuoteInfo.takerAmount)
-            .toNumber();
-    }
-    // (bestCaseMaker - worstCaseMaker) / bestCaseMaker
-    // where bestCaseMaker >= worstCaseMaker
-    return quote.bestCaseQuoteInfo.makerAmount
-        .minus(quote.worstCaseQuoteInfo.makerAmount)
-        .div(quote.bestCaseQuoteInfo.makerAmount)
-        .toNumber();
+    return quote.worstCaseQuoteInfo.slippage;
 }

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -208,6 +208,7 @@ export type SwapQuote = MarketBuySwapQuote | MarketSellSwapQuote;
  * makerTokenAmount: The amount of makerAsset that will be acquired through the swap.
  * protocolFeeInWeiAmount: The amount of ETH to pay (in WEI) as protocol fee to perform the swap for desired asset.
  * gas: Amount of estimated gas needed to fill the quote.
+ * slippage: Amount of slippage to allow for.
  */
 export interface SwapQuoteInfo {
     feeTakerTokenAmount: BigNumber;
@@ -216,6 +217,7 @@ export interface SwapQuoteInfo {
     makerAmount: BigNumber;
     protocolFeeInWeiAmount: BigNumber;
     gas: number;
+    slippage: number;
 }
 
 /**

--- a/packages/asset-swapper/test/exchange_proxy_swap_quote_consumer_test.ts
+++ b/packages/asset-swapper/test/exchange_proxy_swap_quote_consumer_test.ts
@@ -125,6 +125,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 gas: Math.floor(Math.random() * 8e6),
                 protocolFeeInWeiAmount: getRandomAmount(),
                 feeTakerTokenAmount: getRandomAmount(),
+                slippage: 0,
             },
             worstCaseQuoteInfo: {
                 makerAmount: makerTokenFillAmount,
@@ -133,6 +134,7 @@ describe('ExchangeProxySwapQuoteConsumer', () => {
                 gas: Math.floor(Math.random() * 8e6),
                 protocolFeeInWeiAmount: getRandomAmount(),
                 feeTakerTokenAmount: getRandomAmount(),
+                slippage: 0,
             },
             makerAmountPerEth: getRandomInteger(1, 1e9),
             takerAmountPerEth: getRandomInteger(1, 1e9),

--- a/packages/asset-swapper/test/utils/swap_quote.ts
+++ b/packages/asset-swapper/test/utils/swap_quote.ts
@@ -24,6 +24,7 @@ export async function getFullyFillableSwapQuoteWithNoFeesAsync(
         totalTakerAmount: takerAmount,
         protocolFeeInWeiAmount: protocolFeePerOrder.times(orders.length),
         gas: 200e3,
+        slippage: 0,
     };
 
     const breakdown = {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

We had a base line amount of errors where there was inconsistent slippage between the Orders and what is recalculated in `getMaxQuoteSlippageRate`. To keep things consistent I think we just pass it around in the `worstCaseQuoteInfo` which has already been adjusted by that amount of slippage.

For example, the order would be adjusted by 0.005 slippage and the calculated slippage would be 0.005011....

This could create an inconsistency with the `sellAmount` encoded and the FQT data encoded

```
{
  "functionName": "IncompleteFillSellQuoteError",
  "functionSignature": "adc35ca6",
  "functionArguments": [
    "IncompleteFillSellQuoteError({\n  sellToken: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',\n  soldAmount: 29303021,\n  sellAmount: 29303022\n})"
  ]
}
```

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
