### PR TITLE
fix: Prevent BalancerV2/BeethovenX pool explosion

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "16.49.5",
+        "changes": [
+            {
+                "note": "Fix BalancerV2/BeethovenX loading too many pools on startup",
+                "pr": 420
+            }
+        ]
+    },
+    {
         "version": "16.49.4",
         "changes": [
             {

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
@@ -130,7 +130,13 @@ export class BalancerV2PoolsCache extends PoolsCache {
                         );
                         // Cache this as we progress through
                         const expiresAt = Date.now() + this._cacheTimeMs;
-                        this._cachePoolsForPair(from, to, fromToPools[from][to], expiresAt);
+                        this._cachePoolsForPair(
+                            from,
+                            to,
+                            // Clamp the amount of pools in this pair direction to the max
+                            fromToPools[from][to].slice(0, this.maxPoolsFetched),
+                            expiresAt,
+                        );
                     } catch (err) {
                         this._warningLogger(err, `Failed to load Balancer V2 top pools`);
                         // soldier on
@@ -144,6 +150,8 @@ export class BalancerV2PoolsCache extends PoolsCache {
         query getPools {
             pools(
               first: ${this.maxPoolsFetched},
+              orderBy: swapsCount
+              orderDirection: desc
               where: {
                 tokensList_contains: ["${takerToken}", "${makerToken}"]
               }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In BalancerV2 on boot we load the top 250 pools regardless of tokens.

Loading the top 250 pools could result in certain pairs having a lot of pools. Low `sellAmount` searches in these tiny pools then could blow out our `gasUsed` as they all had pricing for small amounts.



## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
