### PR TITLE
chore: bump ts version to solve type issue with ethereumjs

### DIFF
--- a/contracts/erc20/package.json
+++ b/contracts/erc20/package.json
@@ -79,7 +79,7 @@
         "solhint": "^1.4.1",
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "dependencies": {
         "@0x/base-contract": "^6.5.0",

--- a/contracts/test-utils/package.json
+++ b/contracts/test-utils/package.json
@@ -39,7 +39,7 @@
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
         "tslint": "5.11.0",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "dependencies": {
         "@0x/assert": "^3.0.34",

--- a/contracts/treasury/package.json
+++ b/contracts/treasury/package.json
@@ -69,7 +69,7 @@
         "solhint": "^1.4.1",
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "dependencies": {
         "@0x/base-contract": "^6.5.0",

--- a/contracts/utils/package.json
+++ b/contracts/utils/package.json
@@ -76,7 +76,7 @@
         "solhint": "^1.4.1",
         "truffle": "^5.0.32",
         "tslint": "5.11.0",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "dependencies": {
         "@0x/base-contract": "^6.5.0",

--- a/contracts/zero-ex/package.json
+++ b/contracts/zero-ex/package.json
@@ -79,7 +79,7 @@
         "truffle": "^5.0.32",
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "dependencies": {
         "@0x/base-contract": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "npm-run-all": "^4.1.2",
         "prettier": "1.19.1",
         "source-map-support": "^0.5.6",
-        "typescript": "4.2.2",
+        "typescript": "4.6.3",
         "wsrun": "^5.2.4"
     },
     "resolutions": {

--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -123,7 +123,7 @@
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
         "typemoq": "^2.1.0",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/contract-addresses/package.json
+++ b/packages/contract-addresses/package.json
@@ -30,7 +30,7 @@
     "devDependencies": {
         "gitpkg": "https://github.com/0xProject/gitpkg.git",
         "shx": "^0.2.2",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/contract-artifacts/package.json
+++ b/packages/contract-artifacts/package.json
@@ -36,7 +36,7 @@
         "lodash": "^4.17.11",
         "mocha": "^6.2.0",
         "shx": "^0.2.2",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/contract-wrappers/package.json
+++ b/packages/contract-wrappers/package.json
@@ -52,7 +52,7 @@
         "gitpkg": "https://github.com/0xProject/gitpkg.git",
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
-        "typescript": "4.2.2"
+        "typescript": "4.6.3"
     },
     "dependencies": {
         "@0x/assert": "^3.0.34",

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -62,7 +62,7 @@
         "shx": "^0.2.2",
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
-        "typescript": "4.2.2",
+        "typescript": "4.6.3",
         "web3-provider-engine": "14.0.6",
         "yargs": "^10.0.3"
     },

--- a/packages/protocol-utils/package.json
+++ b/packages/protocol-utils/package.json
@@ -58,7 +58,7 @@
         "sinon": "^4.0.0",
         "tslint": "5.11.0",
         "typedoc": "~0.16.11",
-        "typescript": "4.2.2",
+        "typescript": "4.6.3",
         "web3-provider-engine": "14.0.6"
     },
     "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         // These settings are required for TypeScript project references
         "declaration": true,
         "declarationMap": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "useUnknownInCatchVariables": false
     },
     "exclude": [],
     // The root of the project is just a list of references and does not contain

--- a/yarn.lock
+++ b/yarn.lock
@@ -12136,9 +12136,10 @@ typescript@3.7.x:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
 
-typescript@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+typescript@4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 typescript@^3.8.3:
   version "3.9.7"


### PR DESCRIPTION
## Description

This fixes the [ethereumjs TypeScript issue](https://app.circleci.com/pipelines/github/0xProject/protocol/3290/workflows/44f17c3a-b513-4c7d-8d1b-d4e364b78c05/jobs/16440) blocking publishing by upgrading our TS version to 4.6
<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
