### PR TITLE
Do not initialize BalancerV2SwapInfoCache on unsupported chains [TKR-365]

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "16.57.3",
+        "changes": [
+            {
+                "note": "Fix a runtime error related to BalancerV2SwapInfoCache",
+                "pr": 472
+            }
+        ]
+    },
+    {
         "version": "16.57.2",
         "changes": [
             {

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -777,7 +777,7 @@ export class MarketOperationUtils {
     private async _refreshPoolCacheIfRequiredAsync(takerToken: string, makerToken: string): Promise<void> {
         void Promise.all(
             Object.values(this._sampler.poolsCaches).map(async cache => {
-                if (cache.isFresh(takerToken, makerToken)) {
+                if (!cache || cache.isFresh(takerToken, makerToken)) {
                     return Promise.resolve([]);
                 }
                 return cache.getFreshPoolsForPairAsync(takerToken, makerToken);

--- a/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
@@ -107,7 +107,7 @@ export const TWO_HOP_SOURCE_FILTERS = SourceFilters.all().exclude([
 export const BATCH_SOURCE_FILTERS = SourceFilters.all().exclude([ERC20BridgeSource.MultiHop, ERC20BridgeSource.Native]);
 
 export type PoolsCacheMap = { [key in Exclude<SourcesWithPoolsCache, ERC20BridgeSource.BalancerV2>]: PoolsCache } & {
-    [ERC20BridgeSource.BalancerV2]: BalancerV2SwapInfoCache;
+    [ERC20BridgeSource.BalancerV2]: BalancerV2SwapInfoCache | undefined;
 };
 
 // tslint:disable:no-inferred-empty-object-type no-unbound-method
@@ -151,7 +151,10 @@ export class SamplerOperations {
                   ),
                   [ERC20BridgeSource.Balancer]: new BalancerPoolsCache(),
                   [ERC20BridgeSource.Cream]: new CreamPoolsCache(),
-                  [ERC20BridgeSource.BalancerV2]: new BalancerV2SwapInfoCache(chainId),
+                  [ERC20BridgeSource.BalancerV2]:
+                      BALANCER_V2_VAULT_ADDRESS_BY_CHAIN[chainId] === NULL_ADDRESS
+                          ? undefined
+                          : new BalancerV2SwapInfoCache(chainId),
               };
 
         const aaveSubgraphUrl = AAVE_V2_SUBGRAPH_URL_BY_CHAIN_ID[chainId];
@@ -571,7 +574,7 @@ export class SamplerOperations {
         });
     }
 
-    public getBalancerV2MulthopSellQuotes(
+    public getBalancerV2MultihopSellQuotes(
         vault: string,
         quoteSwaps: BalancerSwapInfo, // Should always be sell swap steps.
         fillSwaps: BalancerSwapInfo, // Should always be sell swap steps.
@@ -592,7 +595,7 @@ export class SamplerOperations {
         });
     }
 
-    public getBalancerV2MulthopBuyQuotes(
+    public getBalancerV2MultihopBuyQuotes(
         vault: string,
         quoteSwaps: BalancerSwapInfo, // Should always be buy swap steps.
         fillSwaps: BalancerSwapInfo, // Should always be a sell quote.
@@ -1499,15 +1502,19 @@ export class SamplerOperations {
                             ),
                         );
                     case ERC20BridgeSource.BalancerV2: {
-                        const swaps = this.poolsCaches[source].getCachedSwapInfoForPair(takerToken, makerToken);
+                        const cache = this.poolsCaches[source];
+                        if (!cache) {
+                            return [];
+                        }
 
+                        const swaps = cache.getCachedSwapInfoForPair(takerToken, makerToken);
                         const vault = BALANCER_V2_VAULT_ADDRESS_BY_CHAIN[this.chainId];
                         if (!swaps || vault === NULL_ADDRESS) {
                             return [];
                         }
                         // Changed to retrieve queryBatchSwap for swap steps > 1 of length
                         return swaps.swapInfoExactIn.map(swapInfo =>
-                            this.getBalancerV2MulthopSellQuotes(vault, swapInfo, swapInfo, takerFillAmounts, source),
+                            this.getBalancerV2MultihopSellQuotes(vault, swapInfo, swapInfo, takerFillAmounts, source),
                         );
                     }
                     case ERC20BridgeSource.Beethovenx: {
@@ -1822,15 +1829,19 @@ export class SamplerOperations {
                             ),
                         );
                     case ERC20BridgeSource.BalancerV2: {
-                        const swaps = this.poolsCaches[source].getCachedSwapInfoForPair(takerToken, makerToken);
+                        const cache = this.poolsCaches[source];
+                        if (!cache) {
+                            return [];
+                        }
 
+                        const swaps = cache.getCachedSwapInfoForPair(takerToken, makerToken);
                         const vault = BALANCER_V2_VAULT_ADDRESS_BY_CHAIN[this.chainId];
                         if (!swaps || vault === NULL_ADDRESS) {
                             return [];
                         }
                         // Changed to retrieve queryBatchSwap for swap steps > 1 of length
                         return swaps.swapInfoExactOut.map((quoteSwapInfo, i) =>
-                            this.getBalancerV2MulthopBuyQuotes(
+                            this.getBalancerV2MultihopBuyQuotes(
                                 vault,
                                 quoteSwapInfo,
                                 swaps.swapInfoExactIn[i],


### PR DESCRIPTION
## Description

Initializing `BalancerV2SwapInfoCache` on an unsupported chain causes a runtime error as `BalancerSDK` tries to read undefined properties.

## Testing instructions

Tested locally that this change prevents runtime error on a chain where Balancer V2 is not supported.

## Types of changes

 * Bug fix (non-breaking change which fixes an issue) 

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
