### PR TITLE
Add Yoshi Exchange support (Fantom) [TKR-270]

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Add GMX and Platypus on Avalanche and Enable KyberDMM on bsc",
                 "pr": 478
+            },
+            {
+                "note": "Add Yoshi Exchange support in Fantom",
+                "pr": 473
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/bridge_source_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/bridge_source_utils.ts
@@ -62,6 +62,7 @@ import {
     UNISWAPV2_ROUTER_BY_CHAIN_ID,
     WAULTSWAP_ROUTER_BY_CHAIN_ID,
     XSIGMA_MAINNET_INFOS,
+    YOSHI_ROUTER_BY_CHAIN_ID,
 } from './constants';
 import { CurveInfo, ERC20BridgeSource, PlatypusInfo } from './types';
 
@@ -565,7 +566,8 @@ export function uniswapV2LikeRouterAddress(
         | ERC20BridgeSource.MorpheusSwap
         | ERC20BridgeSource.SpookySwap
         | ERC20BridgeSource.SpiritSwap
-        | ERC20BridgeSource.BiSwap,
+        | ERC20BridgeSource.BiSwap
+        | ERC20BridgeSource.Yoshi,
 ): string {
     switch (source) {
         case ERC20BridgeSource.UniswapV2:
@@ -616,6 +618,8 @@ export function uniswapV2LikeRouterAddress(
             return SPIRITSWAP_ROUTER_BY_CHAIN_ID[chainId];
         case ERC20BridgeSource.BiSwap:
             return BISWAP_ROUTER_BY_CHAIN_ID[chainId];
+        case ERC20BridgeSource.Yoshi:
+            return YOSHI_ROUTER_BY_CHAIN_ID[chainId];
         default:
             throw new Error(`Unknown UniswapV2 like source ${source}`);
     }

--- a/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
@@ -198,6 +198,7 @@ export const SELL_SOURCE_FILTER_BY_CHAIN_ID = valueByChainId<SourceFilters>(
             ERC20BridgeSource.SpookySwap,
             ERC20BridgeSource.SushiSwap,
             ERC20BridgeSource.Synapse,
+            ERC20BridgeSource.Yoshi,
         ]),
         [ChainId.Celo]: new SourceFilters([
             ERC20BridgeSource.UbeSwap,
@@ -344,6 +345,7 @@ export const BUY_SOURCE_FILTER_BY_CHAIN_ID = valueByChainId<SourceFilters>(
             ERC20BridgeSource.SpookySwap,
             ERC20BridgeSource.SushiSwap,
             ERC20BridgeSource.Synapse,
+            ERC20BridgeSource.Yoshi,
         ]),
         [ChainId.Celo]: new SourceFilters([
             ERC20BridgeSource.UbeSwap,
@@ -2405,6 +2407,13 @@ export const PLATYPUS_ROUTER_BY_CHAIN_ID = valueByChainId<string>(
     NULL_ADDRESS,
 );
 
+export const YOSHI_ROUTER_BY_CHAIN_ID = valueByChainId<string>(
+    {
+        [ChainId.Fantom]: '0xe4a4642b19c4d0cba965673cd51422b1eda0a78d',
+    },
+    NULL_ADDRESS,
+);
+
 export const VIP_ERC20_BRIDGE_SOURCES_BY_CHAIN_ID = valueByChainId<ERC20BridgeSource[]>(
     {
         [ChainId.Mainnet]: [
@@ -2621,6 +2630,7 @@ export const DEFAULT_GAS_SCHEDULE: Required<FeeSchedule> = {
     [ERC20BridgeSource.MorpheusSwap]: uniswapV2CloneGasSchedule,
     [ERC20BridgeSource.SpiritSwap]: uniswapV2CloneGasSchedule,
     [ERC20BridgeSource.SpookySwap]: uniswapV2CloneGasSchedule,
+    [ERC20BridgeSource.Yoshi]: uniswapV2CloneGasSchedule,
     [ERC20BridgeSource.Beethovenx]: () => 100e3,
 };
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -195,6 +195,8 @@ export function getErc20BridgeSourceToBridgeSource(source: ERC20BridgeSource): s
             return encodeBridgeSourceId(BridgeProtocol.UniswapV2, 'SpookySwap');
         case ERC20BridgeSource.MorpheusSwap:
             return encodeBridgeSourceId(BridgeProtocol.UniswapV2, 'MorpheusSwap');
+        case ERC20BridgeSource.Yoshi:
+            return encodeBridgeSourceId(BridgeProtocol.UniswapV2, 'Yoshi');
         case ERC20BridgeSource.AaveV2:
             return encodeBridgeSourceId(BridgeProtocol.AaveV2, 'AaveV2');
         case ERC20BridgeSource.Compound:
@@ -299,6 +301,7 @@ export function createBridgeDataForBridgeOrder(order: OptimizedMarketBridgeOrder
         case ERC20BridgeSource.SpookySwap:
         case ERC20BridgeSource.MorpheusSwap:
         case ERC20BridgeSource.BiSwap:
+        case ERC20BridgeSource.Yoshi:
             const uniswapV2FillData = (order as OptimizedMarketBridgeOrder<UniswapV2FillData>).fillData;
             bridgeData = encoder.encode([uniswapV2FillData.router, uniswapV2FillData.tokenAddressPath]);
             break;
@@ -526,6 +529,7 @@ export const BRIDGE_ENCODERS: {
     [ERC20BridgeSource.SpookySwap]: routerAddressPathEncoder,
     [ERC20BridgeSource.MorpheusSwap]: routerAddressPathEncoder,
     [ERC20BridgeSource.BiSwap]: routerAddressPathEncoder,
+    [ERC20BridgeSource.Yoshi]: routerAddressPathEncoder,
     // Avalanche
     [ERC20BridgeSource.GMX]: gmxAddressPathEncoder,
     [ERC20BridgeSource.Platypus]: platypusAddressPathEncoder,

--- a/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
@@ -1462,6 +1462,7 @@ export class SamplerOperations {
                     case ERC20BridgeSource.UbeSwap:
                     case ERC20BridgeSource.SpiritSwap:
                     case ERC20BridgeSource.SpookySwap:
+                    case ERC20BridgeSource.Yoshi:
                     case ERC20BridgeSource.MorpheusSwap:
                     case ERC20BridgeSource.BiSwap:
                         const uniLikeRouter = uniswapV2LikeRouterAddress(this.chainId, source);
@@ -1792,6 +1793,7 @@ export class SamplerOperations {
                     case ERC20BridgeSource.UbeSwap:
                     case ERC20BridgeSource.SpiritSwap:
                     case ERC20BridgeSource.SpookySwap:
+                    case ERC20BridgeSource.Yoshi:
                     case ERC20BridgeSource.MorpheusSwap:
                     case ERC20BridgeSource.BiSwap:
                         const uniLikeRouter = uniswapV2LikeRouterAddress(this.chainId, source);

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -103,6 +103,7 @@ export enum ERC20BridgeSource {
     SpookySwap = 'SpookySwap',
     Beethovenx = 'Beethovenx',
     MorpheusSwap = 'MorpheusSwap',
+    Yoshi = 'Yoshi',
     Geist = 'Geist',
 }
 export type SourcesWithPoolsCache =


### PR DESCRIPTION
## Description

Add Yoshi Exchange support in Fantom

## Testing instructions

Run 0x-api locally. 

## Types of changes

* New feature (non-breaking change which adds functionality) 

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
