### PR TITLE
Update reference.mdx

### DIFF
--- a/packages/asset-swapper/docs/reference.mdx
+++ b/packages/asset-swapper/docs/reference.mdx
@@ -1897,7 +1897,7 @@ ___
 
 # Interface: SwapQuoteRequestOpts
 
-slippagePercentage: The percentage buffer to add to account for slippage. Affects max ETH price estimates. Defaults to 0.2 (20%).
+slippagePercentage: The percentage buffer to add to account for slippage. Affects max ETH price estimates. Defaults to 0.01 (1%).
 gasPrice: gas price to determine protocolFee amount, default to ethGasStation fast amount
 
 


### PR DESCRIPTION
## Description

Aligning reference documentation with `DEFAULT_QUOTE_SLIPPAGE_PERCENTAGE` value from https://github.com/0xProject/0x-api/blob/c74e31c2197ff9231b4856ef6ff0680f22905aa2/src/constants.ts#L26

## Testing instructions

N/A

## Types of changes

Reference documentation update

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.