### PR TITLE
Remove references to `custom-no-magic-numbers` ts lint rule [TKR-484]

### DIFF
--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -95,7 +95,6 @@ export { DEFAULT_FEE_SCHEDULE, DEFAULT_GAS_SCHEDULE } from './utils/market_opera
 
 export const POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS = new BigNumber(30000);
 
-// tslint:disable-next-line: custom-no-magic-numbers
 export const KEEP_ALIVE_TTL = 5 * 60 * ONE_SECOND_MS;
 
 export const constants = {

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -61,7 +61,6 @@ import {
     requiresTransformERC20,
 } from './quote_consumer_utils';
 
-// tslint:disable-next-line:custom-no-magic-numbers
 const MAX_UINT256 = new BigNumber(2).pow(256).minus(1);
 const { NULL_ADDRESS, NULL_BYTES, ZERO_AMOUNT } = constants;
 

--- a/packages/asset-swapper/src/utils/alt_mm_implementation_utils.ts
+++ b/packages/asset-swapper/src/utils/alt_mm_implementation_utils.ts
@@ -105,7 +105,6 @@ function parseIndicativeQuoteResponseFromAltMM(
         // HACK: alt implementation does not return an expiration with indicative quotes
         // return now + { IMPUTED EXPIRY SECONDS } to have it included after order checks
         expiry:
-            // tslint:disable-next-line:custom-no-magic-numbers
             new BigNumber(Date.now() / 1000)
                 .integerValue(BigNumber.ROUND_DOWN)
                 .plus(constants.ALT_MM_IMPUTED_INDICATIVE_EXPIRY_SECONDS),
@@ -243,7 +242,6 @@ export async function returnQuoteFromAltMMAsync<ResponseT>(
     // empty response will get filtered out in validation
     const emptyResponse = {};
 
-    // tslint:disable-next-line:custom-no-magic-numbers
     if (response.status !== SUCCESS_CODE) {
         const rejectedRequestInfo = {
             status: response.status,

--- a/packages/asset-swapper/src/utils/alt_mm_implementation_utils.ts
+++ b/packages/asset-swapper/src/utils/alt_mm_implementation_utils.ts
@@ -104,10 +104,9 @@ function parseIndicativeQuoteResponseFromAltMM(
         takerAmount,
         // HACK: alt implementation does not return an expiration with indicative quotes
         // return now + { IMPUTED EXPIRY SECONDS } to have it included after order checks
-        expiry:
-            new BigNumber(Date.now() / 1000)
-                .integerValue(BigNumber.ROUND_DOWN)
-                .plus(constants.ALT_MM_IMPUTED_INDICATIVE_EXPIRY_SECONDS),
+        expiry: new BigNumber(Date.now() / 1000)
+            .integerValue(BigNumber.ROUND_DOWN)
+            .plus(constants.ALT_MM_IMPUTED_INDICATIVE_EXPIRY_SECONDS),
     };
 }
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/aave_reserves_cache.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/aave_reserves_cache.ts
@@ -40,7 +40,6 @@ interface Cache {
     [key: string]: AaveReserve[];
 }
 
-// tslint:disable-next-line:custom-no-magic-numbers
 const RESERVES_REFRESH_INTERVAL_MS = 30 * constants.ONE_MINUTE_MS;
 
 /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/compound_ctoken_cache.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/compound_ctoken_cache.ts
@@ -19,7 +19,6 @@ interface Cache {
     [key: string]: CToken;
 }
 
-// tslint:disable-next-line:custom-no-magic-numbers
 const CTOKEN_REFRESH_INTERVAL_MS = 30 * constants.ONE_MINUTE_MS;
 
 /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
@@ -37,7 +37,7 @@ import {
     UniswapV3FillData,
 } from './types';
 
-// tslint:disable: custom-no-magic-numbers no-bitwise
+// tslint:disable: no-bitwise
 
 export const ERC20_PROXY_ID = '0xf47261b0';
 export const WALLET_SIGNATURE = '0x04';
@@ -2472,7 +2472,6 @@ const uniswapV2CloneGasSchedule = (fillData?: FillData) => {
  * I.e remove the overhead cost of ExchangeProxy (130k) and
  * the ethereum transaction cost (21k)
  */
-// tslint:disable:custom-no-magic-numbers
 export const DEFAULT_GAS_SCHEDULE: Required<GasSchedule> = {
     [ERC20BridgeSource.Native]: fillData => {
         // TODO jacob re-order imports so there is no circular rependency with SignedNativeOrder
@@ -2697,10 +2696,7 @@ export const POSITIVE_SLIPPAGE_FEE_TRANSFORMER_GAS = new BigNumber(20000);
 
 export const DEFAULT_FEE_ESTIMATE = { gas: 0, fee: ZERO_AMOUNT };
 
-// tslint:enable:custom-no-magic-numbers
-
 export const DEFAULT_GET_MARKET_ORDERS_OPTS: Omit<GetMarketOrdersOpts, 'gasPrice'> = {
-    // tslint:disable-next-line: custom-no-magic-numbers
     runLimit: 2 ** 15,
     excludedSources: [],
     excludedFeeSources: [],

--- a/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
@@ -14,7 +14,7 @@ import { dexSampleToFill, ethToOutputAmount, nativeOrderToFill } from './fills';
 import { Path, PathPenaltyOpts } from './path';
 import { DexSample, ERC20BridgeSource, FeeSchedule, Fill, FillAdjustor, FillData, SamplerMetrics } from './types';
 
-// tslint:disable: prefer-for-of custom-no-magic-numbers completed-docs no-bitwise
+// tslint:disable: prefer-for-of completed-docs no-bitwise
 
 // NOTE: The Rust router will panic with less than 3 samples
 const MIN_NUM_SAMPLE_INPUTS = 3;

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_utils.ts
@@ -10,9 +10,7 @@ import { BALANCER_MAX_POOLS_FETCHED, BALANCER_TOP_POOLS_FETCHED } from '../const
 import { NoOpPoolsCache } from './no_op_pools_cache';
 import { AbstractPoolsCache, CacheValue, PoolsCache } from './pools_cache';
 
-// tslint:disable:custom-no-magic-numbers
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-// tslint:enable:custom-no-magic-numbers
 // tslint:disable: member-ordering
 
 const BALANCER_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer';

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils.ts
@@ -18,7 +18,6 @@ const BEETHOVEN_X_SUBGRAPH_URL_BY_CHAIN = new Map<ChainId, string>([
     [ChainId.Fantom, 'https://api.thegraph.com/subgraphs/name/beethovenxfi/beethovenx'],
 ]);
 
-// tslint:disable-next-line:custom-no-magic-numbers
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 interface BalancerPoolResponse {

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils_new.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/balancer_v2_utils_new.ts
@@ -20,7 +20,6 @@ import { BalancerSwapInfo, BalancerSwaps } from '../types';
 import { CacheValue, EMPTY_BALANCER_SWAPS, SwapInfoCache } from './pair_swaps_cache';
 import { SubgraphPoolDataService } from './sgPoolDataService';
 
-// tslint:disable-next-line:custom-no-magic-numbers
 const ONE_DAY_MS = 24 * 60 * 60 * ONE_SECOND_MS;
 
 export interface BalancerPoolResponse {

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/pair_swaps_cache.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/pair_swaps_cache.ts
@@ -7,12 +7,10 @@ export interface CacheValue {
     balancerSwaps: BalancerSwaps;
 }
 
-// tslint:disable:custom-no-magic-numbers
 // Cache results for 30mins
 const DEFAULT_CACHE_TIME_MS = (ONE_HOUR_IN_SECONDS / 2) * ONE_SECOND_MS;
 const DEFAULT_TIMEOUT_MS = ONE_SECOND_MS;
 export const EMPTY_BALANCER_SWAPS = { swapInfoExactIn: [], swapInfoExactOut: [] };
-// tslint:enable:custom-no-magic-numbers
 
 /**
  * Caches SwapInfo for a pair of tokens.

--- a/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/pools_cache.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/pools_cache/pools_cache.ts
@@ -7,11 +7,9 @@ export interface CacheValue {
     pools: Pool[];
 }
 
-// tslint:disable:custom-no-magic-numbers
 // Cache results for 30mins
 const DEFAULT_CACHE_TIME_MS = (ONE_HOUR_IN_SECONDS / 2) * ONE_SECOND_MS;
 const DEFAULT_TIMEOUT_MS = 3000;
-// tslint:enable:custom-no-magic-numbers
 
 export interface PoolsCache {
     getFreshPoolsForPairAsync(takerToken: string, makerToken: string, timeoutMs?: number): Promise<Pool[]>;


### PR DESCRIPTION
## Description

`custom-no-magic-numbers` have been disabled in a previous PR. 
This PR removes the remaining references to the disabled rule. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
