### PR TITLE
Remove SignatureType definition from protocol-utils

### DIFF
--- a/packages/protocol-utils/CHANGELOG.json
+++ b/packages/protocol-utils/CHANGELOG.json
@@ -1,5 +1,9 @@
 [
     {
+        "version": "11.17.0",
+        "changes": [{ "note": "Remove `SignatureType` definition in favor of the definition in @0x/types" }]
+    },
+    {
         "timestamp": 1661145612,
         "version": "11.16.4",
         "changes": [

--- a/packages/protocol-utils/src/orders.ts
+++ b/packages/protocol-utils/src/orders.ts
@@ -1,6 +1,6 @@
 import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
 import { SupportedProvider } from '@0x/subproviders';
-import { EIP712TypedData } from '@0x/types';
+import { EIP712TypedData, SignatureType } from '@0x/types';
 import { BigNumber, hexUtils, NULL_ADDRESS } from '@0x/utils';
 
 import { ZERO } from './constants';
@@ -16,7 +16,6 @@ import {
     ethSignHashWithKey,
     ethSignHashWithProviderAsync,
     Signature,
-    SignatureType,
 } from './signature_utils';
 
 const COMMON_ORDER_DEFAULT_VALUES = {

--- a/packages/protocol-utils/src/signature_utils.ts
+++ b/packages/protocol-utils/src/signature_utils.ts
@@ -1,19 +1,8 @@
 import { SupportedProvider } from '@0x/subproviders';
-import { EIP712TypedData } from '@0x/types';
+import { EIP712TypedData, SignatureType } from '@0x/types';
 import { hexUtils, providerUtils, signTypedDataUtils } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import * as ethjs from 'ethereumjs-util';
-
-/**
- * Valid signature types on the Exchange Proxy.
- */
-export enum SignatureType {
-    Illegal = 0,
-    Invalid = 1,
-    EIP712 = 2,
-    EthSign = 3,
-    PreSigned = 4,
-}
 
 /**
  * Represents a raw EC signature.


### PR DESCRIPTION
## Description

We have two conflicting definitions of `SignatureType`.

```
// @0x/types

export declare enum SignatureType {
    Illegal = 0,
    Invalid = 1,
    EIP712 = 2,
    EthSign = 3,
    Wallet = 4,
    Validator = 5,
    PreSigned = 6,
    EIP1271Wallet = 7,
    NSignatureTypes = 8
}
```

```
// @0x/protocol-utils

export declare enum SignatureType {
    Illegal = 0,
    Invalid = 1,
    EIP712 = 2,
    EthSign = 3,
    PreSigned = 4
}
```

Since the `@0x/types` definition seems more comprehensive, remove the definition in this repository and import the one from `@0x/types`.

Since this removes an export from the library, bump minor version.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
