### PR TITLE
fix: Migrate transformers to smart contract compatible `unsafeTransformerTransfer` [TKR-587]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -60,6 +60,7 @@ lib
 /contracts/dev-utils/test/generated-wrappers
 /contracts/dev-utils/generated-artifacts
 /contracts/dev-utils/test/generated-artifacts
+/contracts/zero-ex/foundry-artifacts
 /contracts/zero-ex/generated-wrappers
 /contracts/zero-ex/test/generated-wrappers
 /contracts/zero-ex/generated-artifacts

--- a/contracts/zero-ex/contracts/src/transformers/AffiliateFeeTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/AffiliateFeeTransformer.sol
@@ -61,7 +61,7 @@ contract AffiliateFeeTransformer is Transformer {
                 amount = LibERC20Transformer.getTokenBalanceOf(fees[i].token, address(this));
             }
             if (amount != 0) {
-                fees[i].token.transformerTransfer(fees[i].recipient, amount);
+                fees[i].token.unsafeTransformerTransfer(fees[i].recipient, amount);
             }
         }
 

--- a/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
@@ -44,7 +44,8 @@ library LibERC20Transformer {
         uint256 amount
     ) internal {
         if (isTokenETH(token)) {
-            to.transfer(amount);
+            (bool sent,) = to.call{value: amount}("");
+            require(sent, "LibERC20Transformer/FAILED_TO_SEND_ETHER");
         } else {
             token.compatTransfer(to, amount);
         }

--- a/contracts/zero-ex/contracts/src/transformers/PayTakerTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/PayTakerTransformer.sol
@@ -65,7 +65,7 @@ contract PayTakerTransformer is Transformer {
                 amount = data.tokens[i].getTokenBalanceOf(address(this));
             }
             if (amount != 0) {
-                data.tokens[i].transformerTransfer(context.recipient, amount);
+                data.tokens[i].unsafeTransformerTransfer(context.recipient, amount);
             }
         }
         return LibERC20Transformer.TRANSFORMER_SUCCESS;

--- a/contracts/zero-ex/contracts/src/transformers/PositiveSlippageFeeTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/PositiveSlippageFeeTransformer.sol
@@ -53,7 +53,7 @@ contract PositiveSlippageFeeTransformer is Transformer {
         uint256 transformerAmount = LibERC20Transformer.getTokenBalanceOf(fee.token, address(this));
         if (transformerAmount > fee.bestCaseAmount) {
             uint256 positiveSlippageAmount = transformerAmount - fee.bestCaseAmount;
-            fee.token.transformerTransfer(fee.recipient, positiveSlippageAmount);
+            fee.token.unsafeTransformerTransfer(fee.recipient, positiveSlippageAmount);
         }
 
         return LibERC20Transformer.TRANSFORMER_SUCCESS;


### PR DESCRIPTION
* Since `transfer` only forwards 2300 gas it can cause an `out of gas` revert when the receipient is a smart contract.

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
