### PR TITLE
Add Solidity linter

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -8,7 +8,6 @@
         "code-complexity": "off",
         "const-name-snakecase": "error",
         "function-max-lines": "off",
-        "ordering": "error",
         "max-line-length": ["error", 120],
         "no-inline-assembly": "off",
         "quotes": ["error", "double"],

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,8 @@
 {
     "extends": "solhint:recommended",
+    "plugins": ["prettier"],
     "rules": {
+        "prettier/prettier": "error",
         "avoid-low-level-calls": "off",
         "avoid-tx-origin": "warn",
         "code-complexity": "off",

--- a/.solhint.json
+++ b/.solhint.json
@@ -12,6 +12,7 @@
         "max-line-length": ["error", 120],
         "no-inline-assembly": "off",
         "quotes": ["error", "double"],
-        "no-empty-blocks": "off"
+        "no-empty-blocks": "off",
+        "compiler-version": "off"
     }
 }

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,15 @@
+{
+    "extends": "solhint:recommended",
+    "rules": {
+        "avoid-low-level-calls": "off",
+        "avoid-tx-origin": "warn",
+        "code-complexity": "off",
+        "const-name-snakecase": "error",
+        "function-max-lines": "off",
+        "ordering": "error",
+        "max-line-length": ["error", 120],
+        "no-inline-assembly": "off",
+        "quotes": ["error", "double"],
+        "no-empty-blocks": "off"
+    }
+}

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,1 @@
+contracts/src/ZRXToken.sol

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,1 +1,1 @@
-contracts/src/ZRXToken.sol
+contracts/erc20/contracts/src/ZRXToken.sol

--- a/contracts/erc20/contracts/src/UnlimitedAllowanceERC20Token.sol
+++ b/contracts/erc20/contracts/src/UnlimitedAllowanceERC20Token.sol
@@ -23,7 +23,8 @@ import "./ERC20Token.sol";
 contract UnlimitedAllowanceERC20Token is ERC20Token {
     uint256 internal constant MAX_UINT = 2**256 - 1;
 
-    /// @dev ERC20 transferFrom, modified such that an allowance of MAX_UINT represents an unlimited allowance. See https://github.com/ethereum/EIPs/issues/717
+    /// @dev ERC20 transferFrom, modified such that an allowance of MAX_UINT represents an unlimited allowance.
+    // See https://github.com/ethereum/EIPs/issues/717
     /// @param _from Address to transfer from.
     /// @param _to Address to transfer to.
     /// @param _value Amount to transfer.

--- a/contracts/erc20/contracts/src/WETH9.sol
+++ b/contracts/erc20/contracts/src/WETH9.sol
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// solhint-disable
 pragma solidity ^0.5.9;
 
 contract WETH9 {

--- a/contracts/erc20/contracts/src/ZRXToken.sol
+++ b/contracts/erc20/contracts/src/ZRXToken.sol
@@ -137,13 +137,10 @@ contract UnlimitedAllowanceToken is ERC20Token {
 }
 
 contract ZRXToken is UnlimitedAllowanceToken {
-    // solhint-disable const-name-snakecase
     uint8 public constant decimals = 18;
     uint256 public totalSupply = 10**27; // 1 billion tokens, 18 decimal places
     string public constant name = "0x Protocol Token";
     string public constant symbol = "ZRX";
-
-    // solhint-enableconst-name-snakecase
 
     function ZRXToken() public {
         balances[msg.sender] = totalSupply;

--- a/contracts/erc20/contracts/src/interfaces/IERC20Token.sol
+++ b/contracts/erc20/contracts/src/interfaces/IERC20Token.sol
@@ -19,7 +19,6 @@
 pragma solidity ^0.5.9;
 
 contract IERC20Token {
-    // solhint-disable no-simple-event-func-name
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);

--- a/contracts/erc20/contracts/src/v06/IERC20TokenV06.sol
+++ b/contracts/erc20/contracts/src/v06/IERC20TokenV06.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 interface IERC20TokenV06 {
-    // solhint-disable no-simple-event-func-name
     event Transfer(address indexed from, address indexed to, uint256 value);
 
     event Approval(address indexed owner, address indexed spender, uint256 value);

--- a/contracts/erc20/contracts/test/DummyMultipleReturnERC20Token.sol
+++ b/contracts/erc20/contracts/test/DummyMultipleReturnERC20Token.sol
@@ -39,7 +39,8 @@ contract DummyMultipleReturnERC20Token is DummyERC20Token {
     ) external returns (bool) {
         emit Transfer(_from, _to, _value);
 
-        // HACK: This contract will not compile if we remove `returns (bool)`, so we manually return 64 bytes (equiavalent to true, true)
+        // HACK: This contract will not compile if we remove `returns (bool)`, so we manually return 64 bytes
+        // (equiavalent to true, true)
         assembly {
             mstore(0, 1)
             mstore(32, 1)

--- a/contracts/erc20/contracts/test/DummyMultipleReturnERC20Token.sol
+++ b/contracts/erc20/contracts/test/DummyMultipleReturnERC20Token.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.5;
 
 import "./DummyERC20Token.sol";
 
-// solhint-disable no-empty-blocks
 contract DummyMultipleReturnERC20Token is DummyERC20Token {
     constructor(
         string memory _name,

--- a/contracts/erc20/contracts/test/DummyNoReturnERC20Token.sol
+++ b/contracts/erc20/contracts/test/DummyNoReturnERC20Token.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.5;
 
 import "./DummyERC20Token.sol";
 
-// solhint-disable no-empty-blocks
 contract DummyNoReturnERC20Token is DummyERC20Token {
     constructor(
         string memory _name,

--- a/contracts/erc20/contracts/test/UntransferrableDummyERC20Token.sol
+++ b/contracts/erc20/contracts/test/UntransferrableDummyERC20Token.sol
@@ -20,8 +20,6 @@ pragma solidity ^0.5.5;
 
 import "./DummyERC20Token.sol";
 
-// solhint-disable no-empty-blocks
-// solhint-disable no-unused-vars
 contract UntransferrableDummyERC20Token is DummyERC20Token {
     constructor(
         string memory _name,

--- a/contracts/treasury/contracts/src/ZrxTreasury.sol
+++ b/contracts/treasury/contracts/src/ZrxTreasury.sol
@@ -83,11 +83,8 @@ contract ZrxTreasury is IZrxTreasury {
         );
     }
 
-    // solhint-disable
     /// @dev Allows this contract to receive ether.
     receive() external payable {}
-
-    // solhint-enable
 
     /// @dev Updates the proposal and quorum thresholds to the given
     ///      values. Note that this function is only callable by the

--- a/contracts/utils/contracts/src/Authorizable.sol
+++ b/contracts/utils/contracts/src/Authorizable.sol
@@ -23,7 +23,6 @@ import "./LibAuthorizableRichErrors.sol";
 import "./LibRichErrors.sol";
 import "./Ownable.sol";
 
-// solhint-disable no-empty-blocks
 contract Authorizable is Ownable, IAuthorizable {
     /// @dev Only authorized addresses can invoke functions with this modifier.
     modifier onlyAuthorized() {

--- a/contracts/utils/contracts/src/DeploymentConstants.sol
+++ b/contracts/utils/contracts/src/DeploymentConstants.sol
@@ -59,93 +59,93 @@ contract DeploymentConstants {
     address private constant DODO_HELPER = 0x533dA777aeDCE766CEAe696bf90f8541A4bA80Eb;
 
     // // Ropsten addresses ///////////////////////////////////////////////////////
-    // /// @dev Mainnet address of the WETH contract.
+    /// @dev Mainnet address of the WETH contract.
     // address constant private WETH_ADDRESS = 0xc778417E063141139Fce010982780140Aa0cD5Ab;
-    // /// @dev Mainnet address of the KyberNetworkProxy contract.
+    /// @dev Mainnet address of the KyberNetworkProxy contract.
     // address constant private KYBER_NETWORK_PROXY_ADDRESS = 0xd719c34261e099Fdb33030ac8909d5788D3039C4;
-    // /// @dev Mainnet address of the `UniswapExchangeFactory` contract.
+    /// @dev Mainnet address of the `UniswapExchangeFactory` contract.
     // address constant private UNISWAP_EXCHANGE_FACTORY_ADDRESS = 0x9c83dCE8CA20E9aAF9D3efc003b2ea62aBC08351;
-    // /// @dev Mainnet address of the `UniswapV2Router01` contract.
+    /// @dev Mainnet address of the `UniswapV2Router01` contract.
     // address constant private UNISWAP_V2_ROUTER_01_ADDRESS = 0xf164fC0Ec4E93095b804a4795bBe1e041497b92a;
-    // /// @dev Mainnet address of the Eth2Dai `MatchingMarket` contract.
+    /// @dev Mainnet address of the Eth2Dai `MatchingMarket` contract.
     // address constant private ETH2DAI_ADDRESS = address(0);
-    // /// @dev Mainnet address of the `ERC20BridgeProxy` contract
+    /// @dev Mainnet address of the `ERC20BridgeProxy` contract
     // address constant private ERC20_BRIDGE_PROXY_ADDRESS = 0xb344afeD348de15eb4a9e180205A2B0739628339;
     // ///@dev Mainnet address of the `Dai` (multi-collateral) contract
     // address constant private DAI_ADDRESS = address(0);
-    // /// @dev Mainnet address of the `Chai` contract
+    /// @dev Mainnet address of the `Chai` contract
     // address constant private CHAI_ADDRESS = address(0);
-    // /// @dev Mainnet address of the 0x DevUtils contract.
+    /// @dev Mainnet address of the 0x DevUtils contract.
     // address constant private DEV_UTILS_ADDRESS = 0xC812AF3f3fBC62F76ea4262576EC0f49dB8B7f1c;
-    // /// @dev Kyber ETH pseudo-address.
+    /// @dev Kyber ETH pseudo-address.
     // address constant internal KYBER_ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    // /// @dev Mainnet address of the dYdX contract.
+    /// @dev Mainnet address of the dYdX contract.
     // address constant private DYDX_ADDRESS = address(0);
-    // /// @dev Mainnet address of the GST2 contract
+    /// @dev Mainnet address of the GST2 contract
     // address constant private GST_ADDRESS = address(0);
-    // /// @dev Mainnet address of the GST Collector
+    /// @dev Mainnet address of the GST Collector
     // address constant private GST_COLLECTOR_ADDRESS = address(0);
-    // /// @dev Mainnet address of the mStable mUSD contract.
+    /// @dev Mainnet address of the mStable mUSD contract.
     // address constant private MUSD_ADDRESS = 0x4E1000616990D83e56f4b5fC6CC8602DcfD20459;
 
     // // Rinkeby addresses ///////////////////////////////////////////////////////
-    // /// @dev Mainnet address of the WETH contract.
+    /// @dev Mainnet address of the WETH contract.
     // address constant private WETH_ADDRESS = 0xc778417E063141139Fce010982780140Aa0cD5Ab;
-    // /// @dev Mainnet address of the KyberNetworkProxy contract.
+    /// @dev Mainnet address of the KyberNetworkProxy contract.
     // address constant private KYBER_NETWORK_PROXY_ADDRESS = 0x0d5371e5EE23dec7DF251A8957279629aa79E9C5;
-    // /// @dev Mainnet address of the `UniswapExchangeFactory` contract.
+    /// @dev Mainnet address of the `UniswapExchangeFactory` contract.
     // address constant private UNISWAP_EXCHANGE_FACTORY_ADDRESS = 0xf5D915570BC477f9B8D6C0E980aA81757A3AaC36;
-    // /// @dev Mainnet address of the `UniswapV2Router01` contract.
+    /// @dev Mainnet address of the `UniswapV2Router01` contract.
     // address constant private UNISWAP_V2_ROUTER_01_ADDRESS = 0xf164fC0Ec4E93095b804a4795bBe1e041497b92a;
-    // /// @dev Mainnet address of the Eth2Dai `MatchingMarket` contract.
+    /// @dev Mainnet address of the Eth2Dai `MatchingMarket` contract.
     // address constant private ETH2DAI_ADDRESS = address(0);
-    // /// @dev Mainnet address of the `ERC20BridgeProxy` contract
+    /// @dev Mainnet address of the `ERC20BridgeProxy` contract
     // address constant private ERC20_BRIDGE_PROXY_ADDRESS = 0xA2AA4bEFED748Fba27a3bE7Dfd2C4b2c6DB1F49B;
     // ///@dev Mainnet address of the `Dai` (multi-collateral) contract
     // address constant private DAI_ADDRESS = address(0);
-    // /// @dev Mainnet address of the `Chai` contract
+    /// @dev Mainnet address of the `Chai` contract
     // address constant private CHAI_ADDRESS = address(0);
-    // /// @dev Mainnet address of the 0x DevUtils contract.
+    /// @dev Mainnet address of the 0x DevUtils contract.
     // address constant private DEV_UTILS_ADDRESS = 0x46B5BC959e8A754c0256FFF73bF34A52Ad5CdfA9;
-    // /// @dev Kyber ETH pseudo-address.
+    /// @dev Kyber ETH pseudo-address.
     // address constant internal KYBER_ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    // /// @dev Mainnet address of the dYdX contract.
+    /// @dev Mainnet address of the dYdX contract.
     // address constant private DYDX_ADDRESS = address(0);
-    // /// @dev Mainnet address of the GST2 contract
+    /// @dev Mainnet address of the GST2 contract
     // address constant private GST_ADDRESS = address(0);
-    // /// @dev Mainnet address of the GST Collector
+    /// @dev Mainnet address of the GST Collector
     // address constant private GST_COLLECTOR_ADDRESS = address(0);
-    // /// @dev Mainnet address of the mStable mUSD contract.
+    /// @dev Mainnet address of the mStable mUSD contract.
     // address constant private MUSD_ADDRESS = address(0);
 
     // // Kovan addresses /////////////////////////////////////////////////////////
-    // /// @dev Kovan address of the WETH contract.
+    /// @dev Kovan address of the WETH contract.
     // address constant private WETH_ADDRESS = 0xd0A1E359811322d97991E03f863a0C30C2cF029C;
-    // /// @dev Kovan address of the KyberNetworkProxy contract.
+    /// @dev Kovan address of the KyberNetworkProxy contract.
     // address constant private KYBER_NETWORK_PROXY_ADDRESS = 0x692f391bCc85cefCe8C237C01e1f636BbD70EA4D;
-    // /// @dev Kovan address of the `UniswapExchangeFactory` contract.
+    /// @dev Kovan address of the `UniswapExchangeFactory` contract.
     // address constant private UNISWAP_EXCHANGE_FACTORY_ADDRESS = 0xD3E51Ef092B2845f10401a0159B2B96e8B6c3D30;
-    // /// @dev Kovan address of the `UniswapV2Router01` contract.
+    /// @dev Kovan address of the `UniswapV2Router01` contract.
     // address constant private UNISWAP_V2_ROUTER_01_ADDRESS = 0xf164fC0Ec4E93095b804a4795bBe1e041497b92a;
-    // /// @dev Kovan address of the Eth2Dai `MatchingMarket` contract.
+    /// @dev Kovan address of the Eth2Dai `MatchingMarket` contract.
     // address constant private ETH2DAI_ADDRESS = 0xe325acB9765b02b8b418199bf9650972299235F4;
-    // /// @dev Kovan address of the `ERC20BridgeProxy` contract
+    /// @dev Kovan address of the `ERC20BridgeProxy` contract
     // address constant private ERC20_BRIDGE_PROXY_ADDRESS = 0x3577552C1Fb7A44aD76BeEB7aB53251668A21F8D;
-    // /// @dev Kovan address of the `Chai` contract
+    /// @dev Kovan address of the `Chai` contract
     // address constant private CHAI_ADDRESS = address(0);
-    // /// @dev Kovan address of the `Dai` (multi-collateral) contract
+    /// @dev Kovan address of the `Dai` (multi-collateral) contract
     // address constant private DAI_ADDRESS = 0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa;
-    // /// @dev Kovan address of the 0x DevUtils contract.
+    /// @dev Kovan address of the 0x DevUtils contract.
     // address constant private DEV_UTILS_ADDRESS = 0x9402639A828BdF4E9e4103ac3B69E1a6E522eB59;
-    // /// @dev Kyber ETH pseudo-address.
+    /// @dev Kyber ETH pseudo-address.
     // address constant internal KYBER_ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    // /// @dev Kovan address of the dYdX contract.
+    /// @dev Kovan address of the dYdX contract.
     // address constant private DYDX_ADDRESS = address(0);
-    // /// @dev Kovan address of the GST2 contract
+    /// @dev Kovan address of the GST2 contract
     // address constant private GST_ADDRESS = address(0);
-    // /// @dev Kovan address of the GST Collector
+    /// @dev Kovan address of the GST Collector
     // address constant private GST_COLLECTOR_ADDRESS = address(0);
-    // /// @dev Mainnet address of the mStable mUSD contract.
+    /// @dev Mainnet address of the mStable mUSD contract.
     // address constant private MUSD_ADDRESS = address(0);
 
     /// @dev Overridable way to get the `KyberNetworkProxy` address.

--- a/contracts/utils/contracts/src/DeploymentConstants.sol
+++ b/contracts/utils/contracts/src/DeploymentConstants.sol
@@ -19,7 +19,6 @@
 pragma solidity ^0.5.9;
 
 contract DeploymentConstants {
-
     // Mainnet addresses ///////////////////////////////////////////////////////
     /// @dev Mainnet address of the WETH contract.
     address private constant WETH_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;

--- a/contracts/utils/contracts/src/DeploymentConstants.sol
+++ b/contracts/utils/contracts/src/DeploymentConstants.sol
@@ -19,7 +19,6 @@
 pragma solidity ^0.5.9;
 
 contract DeploymentConstants {
-    // solhint-disable separate-by-one-line-in-contract
 
     // Mainnet addresses ///////////////////////////////////////////////////////
     /// @dev Mainnet address of the WETH contract.

--- a/contracts/utils/contracts/src/LibAddressArrayRichErrors.sol
+++ b/contracts/utils/contracts/src/LibAddressArrayRichErrors.sol
@@ -22,7 +22,6 @@ library LibAddressArrayRichErrors {
     // bytes4(keccak256("MismanagedMemoryError(uint256,uint256)"))
     bytes4 internal constant MISMANAGED_MEMORY_ERROR_SELECTOR = 0x5fc83722;
 
-    // solhint-disable func-name-mixedcase
     function MismanagedMemoryError(uint256 freeMemPtr, uint256 addressArrayEndPtr)
         internal
         pure

--- a/contracts/utils/contracts/src/LibAuthorizableRichErrors.sol
+++ b/contracts/utils/contracts/src/LibAuthorizableRichErrors.sol
@@ -37,7 +37,6 @@ library LibAuthorizableRichErrors {
     // bytes4(keccak256("ZeroCantBeAuthorizedError()"))
     bytes internal constant ZERO_CANT_BE_AUTHORIZED_ERROR_BYTES = hex"57654fe4";
 
-    // solhint-disable func-name-mixedcase
     function AuthorizedAddressMismatchError(address authorized, address target) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(AUTHORIZED_ADDRESS_MISMATCH_ERROR_SELECTOR, authorized, target);
     }

--- a/contracts/utils/contracts/src/LibBytes.sol
+++ b/contracts/utils/contracts/src/LibBytes.sol
@@ -105,7 +105,6 @@ library LibBytes {
                     // Copy whole words front to back
                     // Note: the first check is always true,
                     // this could have been a do-while loop.
-                    // solhint-disable-next-line no-empty-blocks
                     for {
 
                     } lt(source, sEnd) {
@@ -140,7 +139,6 @@ library LibBytes {
                     // 2**255, so they can be safely re-interpreted as signed.
                     // Note: the first check is always true,
                     // this could have been a do-while loop.
-                    // solhint-disable-next-line no-empty-blocks
                     for {
 
                     } slt(dest, dEnd) {

--- a/contracts/utils/contracts/src/LibBytesRichErrors.sol
+++ b/contracts/utils/contracts/src/LibBytesRichErrors.sol
@@ -33,7 +33,6 @@ library LibBytesRichErrors {
     // bytes4(keccak256("InvalidByteOperationError(uint8,uint256,uint256)"))
     bytes4 internal constant INVALID_BYTE_OPERATION_ERROR_SELECTOR = 0x28006595;
 
-    // solhint-disable func-name-mixedcase
     function InvalidByteOperationError(
         InvalidByteOperationErrorCodes errorCode,
         uint256 offset,

--- a/contracts/utils/contracts/src/LibMathRichErrors.sol
+++ b/contracts/utils/contracts/src/LibMathRichErrors.sol
@@ -7,7 +7,6 @@ library LibMathRichErrors {
     // bytes4(keccak256("RoundingError(uint256,uint256,uint256)"))
     bytes4 internal constant ROUNDING_ERROR_SELECTOR = 0x339f3de2;
 
-    // solhint-disable func-name-mixedcase
     function DivisionByZeroError() internal pure returns (bytes memory) {
         return DIVISION_BY_ZERO_ERROR;
     }

--- a/contracts/utils/contracts/src/LibOwnableRichErrors.sol
+++ b/contracts/utils/contracts/src/LibOwnableRichErrors.sol
@@ -7,7 +7,6 @@ library LibOwnableRichErrors {
     // bytes4(keccak256("TransferOwnerToZeroError()"))
     bytes internal constant TRANSFER_OWNER_TO_ZERO_ERROR_BYTES = hex"e69edc3e";
 
-    // solhint-disable func-name-mixedcase
     function OnlyOwnerError(address sender, address owner) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(ONLY_OWNER_ERROR_SELECTOR, sender, owner);
     }

--- a/contracts/utils/contracts/src/LibReentrancyGuardRichErrors.sol
+++ b/contracts/utils/contracts/src/LibReentrancyGuardRichErrors.sol
@@ -22,7 +22,6 @@ library LibReentrancyGuardRichErrors {
     // bytes4(keccak256("IllegalReentrancyError()"))
     bytes internal constant ILLEGAL_REENTRANCY_ERROR_SELECTOR_BYTES = hex"0c3b823f";
 
-    // solhint-disable func-name-mixedcase
     function IllegalReentrancyError() internal pure returns (bytes memory) {
         return ILLEGAL_REENTRANCY_ERROR_SELECTOR_BYTES;
     }

--- a/contracts/utils/contracts/src/LibRichErrors.sol
+++ b/contracts/utils/contracts/src/LibRichErrors.sol
@@ -22,7 +22,6 @@ library LibRichErrors {
     // bytes4(keccak256("Error(string)"))
     bytes4 internal constant STANDARD_ERROR_SELECTOR = 0x08c379a0;
 
-    // solhint-disable func-name-mixedcase
     /// @dev ABI encode a standard, string revert error payload.
     ///      This is the same payload that would be included by a `revert(string)`
     ///      solidity statement. It has the function signature `Error(string)`.
@@ -31,8 +30,6 @@ library LibRichErrors {
     function StandardError(string memory message) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(STANDARD_ERROR_SELECTOR, bytes(message));
     }
-
-    // solhint-enable func-name-mixedcase
 
     /// @dev Reverts an encoded rich revert reason `errorData`.
     /// @param errorData ABI encoded error data.

--- a/contracts/utils/contracts/src/LibSafeMathRichErrors.sol
+++ b/contracts/utils/contracts/src/LibSafeMathRichErrors.sol
@@ -20,7 +20,6 @@ library LibSafeMathRichErrors {
         VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT96
     }
 
-    // solhint-disable func-name-mixedcase
     function Uint256BinOpError(
         BinOpErrorCodes errorCode,
         uint256 a,

--- a/contracts/utils/contracts/src/v06/AuthorizableV06.sol
+++ b/contracts/utils/contracts/src/v06/AuthorizableV06.sol
@@ -24,7 +24,6 @@ import "./errors/LibRichErrorsV06.sol";
 import "./errors/LibAuthorizableRichErrorsV06.sol";
 import "./OwnableV06.sol";
 
-// solhint-disable no-empty-blocks
 contract AuthorizableV06 is OwnableV06, IAuthorizableV06 {
     /// @dev Only authorized addresses can invoke functions with this modifier.
     modifier onlyAuthorized() {

--- a/contracts/utils/contracts/src/v06/LibBytesV06.sol
+++ b/contracts/utils/contracts/src/v06/LibBytesV06.sol
@@ -106,7 +106,6 @@ library LibBytesV06 {
                     // Copy whole words front to back
                     // Note: the first check is always true,
                     // this could have been a do-while loop.
-                    // solhint-disable-next-line no-empty-blocks
                     for {
 
                     } lt(source, sEnd) {
@@ -141,7 +140,6 @@ library LibBytesV06 {
                     // 2**255, so they can be safely re-interpreted as signed.
                     // Note: the first check is always true,
                     // this could have been a do-while loop.
-                    // solhint-disable-next-line no-empty-blocks
                     for {
 
                     } slt(dest, dEnd) {

--- a/contracts/utils/contracts/src/v06/errors/LibAuthorizableRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibAuthorizableRichErrorsV06.sol
@@ -38,7 +38,6 @@ library LibAuthorizableRichErrorsV06 {
     // bytes4(keccak256("ZeroCantBeAuthorizedError()"))
     bytes internal constant ZERO_CANT_BE_AUTHORIZED_ERROR_BYTES = hex"57654fe4";
 
-    // solhint-disable func-name-mixedcase
     function AuthorizedAddressMismatchError(address authorized, address target) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(AUTHORIZED_ADDRESS_MISMATCH_ERROR_SELECTOR, authorized, target);
     }

--- a/contracts/utils/contracts/src/v06/errors/LibBytesRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibBytesRichErrorsV06.sol
@@ -34,7 +34,6 @@ library LibBytesRichErrorsV06 {
     // bytes4(keccak256("InvalidByteOperationError(uint8,uint256,uint256)"))
     bytes4 internal constant INVALID_BYTE_OPERATION_ERROR_SELECTOR = 0x28006595;
 
-    // solhint-disable func-name-mixedcase
     function InvalidByteOperationError(
         InvalidByteOperationErrorCodes errorCode,
         uint256 offset,

--- a/contracts/utils/contracts/src/v06/errors/LibMathRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibMathRichErrorsV06.sol
@@ -26,7 +26,6 @@ library LibMathRichErrorsV06 {
     // bytes4(keccak256("RoundingError(uint256,uint256,uint256)"))
     bytes4 internal constant ROUNDING_ERROR_SELECTOR = 0x339f3de2;
 
-    // solhint-disable func-name-mixedcase
     function DivisionByZeroError() internal pure returns (bytes memory) {
         return DIVISION_BY_ZERO_ERROR;
     }

--- a/contracts/utils/contracts/src/v06/errors/LibOwnableRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibOwnableRichErrorsV06.sol
@@ -25,7 +25,6 @@ library LibOwnableRichErrorsV06 {
     // bytes4(keccak256("TransferOwnerToZeroError()"))
     bytes internal constant TRANSFER_OWNER_TO_ZERO_ERROR_BYTES = hex"e69edc3e";
 
-    // solhint-disable func-name-mixedcase
     function OnlyOwnerError(address sender, address owner) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(ONLY_OWNER_ERROR_SELECTOR, sender, owner);
     }

--- a/contracts/utils/contracts/src/v06/errors/LibReentrancyGuardRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibReentrancyGuardRichErrorsV06.sol
@@ -23,7 +23,6 @@ library LibReentrancyGuardRichErrorsV06 {
     // bytes4(keccak256("IllegalReentrancyError()"))
     bytes internal constant ILLEGAL_REENTRANCY_ERROR_SELECTOR_BYTES = hex"0c3b823f";
 
-    // solhint-disable func-name-mixedcase
     function IllegalReentrancyError() internal pure returns (bytes memory) {
         return ILLEGAL_REENTRANCY_ERROR_SELECTOR_BYTES;
     }

--- a/contracts/utils/contracts/src/v06/errors/LibRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibRichErrorsV06.sol
@@ -23,7 +23,6 @@ library LibRichErrorsV06 {
     // bytes4(keccak256("Error(string)"))
     bytes4 internal constant STANDARD_ERROR_SELECTOR = 0x08c379a0;
 
-    // solhint-disable func-name-mixedcase
     /// @dev ABI encode a standard, string revert error payload.
     ///      This is the same payload that would be included by a `revert(string)`
     ///      solidity statement. It has the function signature `Error(string)`.
@@ -32,8 +31,6 @@ library LibRichErrorsV06 {
     function StandardError(string memory message) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(STANDARD_ERROR_SELECTOR, bytes(message));
     }
-
-    // solhint-enable func-name-mixedcase
 
     /// @dev Reverts an encoded rich revert reason `errorData`.
     /// @param errorData ABI encoded error data.

--- a/contracts/utils/contracts/src/v06/errors/LibSafeMathRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibSafeMathRichErrorsV06.sol
@@ -40,7 +40,6 @@ library LibSafeMathRichErrorsV06 {
         VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT128
     }
 
-    // solhint-disable func-name-mixedcase
     function Uint256BinOpError(
         BinOpErrorCodes errorCode,
         uint256 a,

--- a/contracts/utils/contracts/test/TestAuthorizable.sol
+++ b/contracts/utils/contracts/test/TestAuthorizable.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.9;
 
 import "../src/Authorizable.sol";
 
-// solhint-disable no-empty-blocks
 contract TestAuthorizable is Authorizable {
     function onlyAuthorizedFn() external view onlyAuthorized {}
 }

--- a/contracts/utils/contracts/test/TestRefundable.sol
+++ b/contracts/utils/contracts/test/TestRefundable.sol
@@ -33,9 +33,9 @@ contract TestRefundable is Refundable {
         return _shouldNotRefund;
     }
 
-    function refundFinalBalanceFunction() public payable refundFinalBalance {} // solhint-disable-line no-empty-blocks
+    function refundFinalBalanceFunction() public payable refundFinalBalance {}
 
-    function disableRefundUntilEndFunction() public payable disableRefundUntilEnd {} // solhint-disable-line no-empty-blocks
+    function disableRefundUntilEndFunction() public payable disableRefundUntilEnd {}
 
     function nestedDisableRefundUntilEndFunction() public payable disableRefundUntilEnd returns (uint256) {
         disableRefundUntilEndFunction();

--- a/contracts/zero-ex/contracts/src/IZeroEx.sol
+++ b/contracts/zero-ex/contracts/src/IZeroEx.sol
@@ -57,7 +57,6 @@ interface IZeroEx is
     IERC1155OrdersFeature,
     IERC165Feature
 {
-    // solhint-disable state-visibility
 
     /// @dev Fallback for just receiving ether.
     receive() external payable;

--- a/contracts/zero-ex/contracts/src/IZeroEx.sol
+++ b/contracts/zero-ex/contracts/src/IZeroEx.sol
@@ -57,7 +57,6 @@ interface IZeroEx is
     IERC1155OrdersFeature,
     IERC165Feature
 {
-
     /// @dev Fallback for just receiving ether.
     receive() external payable;
 }

--- a/contracts/zero-ex/contracts/src/ZeroEx.sol
+++ b/contracts/zero-ex/contracts/src/ZeroEx.sol
@@ -29,7 +29,6 @@ import "./errors/LibProxyRichErrors.sol";
 /// @dev An extensible proxy contract that serves as a universal entry point for
 ///      interacting with the 0x protocol.
 contract ZeroEx {
-    // solhint-disable separate-by-one-line-in-contract,indent,var-name-mixedcase
     using LibBytesV06 for bytes;
 
     /// @dev Construct this contract and register the `BootstrapFeature` feature.
@@ -42,8 +41,6 @@ contract ZeroEx {
         BootstrapFeature bootstrap = new BootstrapFeature(bootstrapper);
         LibProxyStorage.getStorage().impls[bootstrap.bootstrap.selector] = address(bootstrap);
     }
-
-    // solhint-disable state-visibility
 
     /// @dev Forwards calls to the appropriate implementation contract.
     fallback() external payable {
@@ -62,8 +59,6 @@ contract ZeroEx {
 
     /// @dev Fallback for just receiving ether.
     receive() external payable {}
-
-    // solhint-enable state-visibility
 
     /// @dev Get the implementation contract of a registered function.
     /// @param selector The function selector.

--- a/contracts/zero-ex/contracts/src/ZeroExOptimized.sol
+++ b/contracts/zero-ex/contracts/src/ZeroExOptimized.sol
@@ -37,8 +37,6 @@ contract ZeroExOptimized {
         LibProxyStorage.getStorage().impls[bootstrap.bootstrap.selector] = address(bootstrap);
     }
 
-    // solhint-disable state-visibility
-
     /// @dev Forwards calls to the appropriate implementation contract.
     fallback() external payable {
         // This is used in assembly below as impls_slot.

--- a/contracts/zero-ex/contracts/src/errors/LibCommonRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibCommonRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibCommonRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function OnlyCallableBySelfError(address sender) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("OnlyCallableBySelfError(address)")), sender);

--- a/contracts/zero-ex/contracts/src/errors/LibCommonRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibCommonRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibCommonRichErrors {
-
     function OnlyCallableBySelfError(address sender) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("OnlyCallableBySelfError(address)")), sender);
     }

--- a/contracts/zero-ex/contracts/src/errors/LibLiquidityProviderRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibLiquidityProviderRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibLiquidityProviderRichErrors {
-
     function LiquidityProviderIncompleteSellError(
         address providerAddress,
         address makerToken,

--- a/contracts/zero-ex/contracts/src/errors/LibLiquidityProviderRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibLiquidityProviderRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibLiquidityProviderRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function LiquidityProviderIncompleteSellError(
         address providerAddress,

--- a/contracts/zero-ex/contracts/src/errors/LibMetaTransactionsRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibMetaTransactionsRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibMetaTransactionsRichErrors {
-
     function InvalidMetaTransactionsArrayLengthsError(uint256 mtxCount, uint256 signatureCount)
         internal
         pure

--- a/contracts/zero-ex/contracts/src/errors/LibMetaTransactionsRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibMetaTransactionsRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibMetaTransactionsRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function InvalidMetaTransactionsArrayLengthsError(uint256 mtxCount, uint256 signatureCount)
         internal

--- a/contracts/zero-ex/contracts/src/errors/LibNFTOrdersRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibNFTOrdersRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibNFTOrdersRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function OverspentEthError(uint256 ethSpent, uint256 ethAvailable) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("OverspentEthError(uint256,uint256)")), ethSpent, ethAvailable);

--- a/contracts/zero-ex/contracts/src/errors/LibNFTOrdersRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibNFTOrdersRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibNFTOrdersRichErrors {
-
     function OverspentEthError(uint256 ethSpent, uint256 ethAvailable) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("OverspentEthError(uint256,uint256)")), ethSpent, ethAvailable);
     }

--- a/contracts/zero-ex/contracts/src/errors/LibNativeOrdersRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibNativeOrdersRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibNativeOrdersRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function ProtocolFeeRefundFailed(address receiver, uint256 refundAmount) internal pure returns (bytes memory) {
         return

--- a/contracts/zero-ex/contracts/src/errors/LibNativeOrdersRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibNativeOrdersRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibNativeOrdersRichErrors {
-
     function ProtocolFeeRefundFailed(address receiver, uint256 refundAmount) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(

--- a/contracts/zero-ex/contracts/src/errors/LibOwnableRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibOwnableRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibOwnableRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function OnlyOwnerError(address sender, address owner) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("OnlyOwnerError(address,address)")), sender, owner);

--- a/contracts/zero-ex/contracts/src/errors/LibOwnableRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibOwnableRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibOwnableRichErrors {
-
     function OnlyOwnerError(address sender, address owner) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("OnlyOwnerError(address,address)")), sender, owner);
     }

--- a/contracts/zero-ex/contracts/src/errors/LibProxyRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibProxyRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibProxyRichErrors {
-
     function NotImplementedError(bytes4 selector) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("NotImplementedError(bytes4)")), selector);
     }

--- a/contracts/zero-ex/contracts/src/errors/LibProxyRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibProxyRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibProxyRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function NotImplementedError(bytes4 selector) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("NotImplementedError(bytes4)")), selector);

--- a/contracts/zero-ex/contracts/src/errors/LibSignatureRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibSignatureRichErrors.sol
@@ -29,8 +29,6 @@ library LibSignatureRichErrors {
         BAD_SIGNATURE_DATA
     }
 
-    // solhint-disable func-name-mixedcase
-
     function SignatureValidationError(
         SignatureValidationErrorCodes code,
         bytes32 hash,

--- a/contracts/zero-ex/contracts/src/errors/LibSimpleFunctionRegistryRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibSimpleFunctionRegistryRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibSimpleFunctionRegistryRichErrors {
-
     function NotInRollbackHistoryError(bytes4 selector, address targetImpl) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(

--- a/contracts/zero-ex/contracts/src/errors/LibSimpleFunctionRegistryRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibSimpleFunctionRegistryRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibSimpleFunctionRegistryRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function NotInRollbackHistoryError(bytes4 selector, address targetImpl) internal pure returns (bytes memory) {
         return

--- a/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibTransformERC20RichErrors {
-    // solhint-disable func-name-mixedcase,separate-by-one-line-in-contract
 
     function InsufficientEthAttachedError(uint256 ethAttached, uint256 ethNeeded) internal pure returns (bytes memory) {
         return

--- a/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibTransformERC20RichErrors {
-
     function InsufficientEthAttachedError(uint256 ethAttached, uint256 ethNeeded) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(

--- a/contracts/zero-ex/contracts/src/errors/LibWalletRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibWalletRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibWalletRichErrors {
-
     function WalletExecuteCallFailedError(
         address wallet,
         address callTarget,

--- a/contracts/zero-ex/contracts/src/errors/LibWalletRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibWalletRichErrors.sol
@@ -20,7 +20,6 @@
 pragma solidity ^0.6.5;
 
 library LibWalletRichErrors {
-    // solhint-disable func-name-mixedcase
 
     function WalletExecuteCallFailedError(
         address wallet,

--- a/contracts/zero-ex/contracts/src/external/FlashWallet.sol
+++ b/contracts/zero-ex/contracts/src/external/FlashWallet.sol
@@ -27,14 +27,10 @@ import "./IFlashWallet.sol";
 
 /// @dev A contract that can execute arbitrary calls from its owner.
 contract FlashWallet is IFlashWallet {
-    // solhint-disable no-unused-vars,indent,no-empty-blocks
     using LibRichErrorsV06 for bytes;
 
-    // solhint-disable
     /// @dev Store the owner/deployer as an immutable to make this contract stateless.
     address public immutable override owner;
-
-    // solhint-enable
 
     constructor() public {
         // The deployer is the owner.
@@ -89,11 +85,8 @@ contract FlashWallet is IFlashWallet {
         }
     }
 
-    // solhint-disable
     /// @dev Allows this contract to receive ether.
     receive() external payable override {}
-
-    // solhint-enable
 
     /// @dev Signal support for receiving ERC1155 tokens.
     /// @param interfaceID The interface ID, as per ERC-165 rules.

--- a/contracts/zero-ex/contracts/src/features/BatchFillNativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/BatchFillNativeOrdersFeature.sol
@@ -44,8 +44,7 @@ contract BatchFillNativeOrdersFeature is IFeature, IBatchFillNativeOrdersFeature
     /// @dev Version of this feature.
     uint256 public immutable override FEATURE_VERSION = _encodeVersion(1, 1, 0);
 
-    constructor(address zeroExAddress) public FixinEIP712(zeroExAddress) {
-    }
+    constructor(address zeroExAddress) public FixinEIP712(zeroExAddress) {}
 
     /// @dev Initialize and register this feature.
     ///      Should be delegatecalled by `Migrate.migrate()`.

--- a/contracts/zero-ex/contracts/src/features/BatchFillNativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/BatchFillNativeOrdersFeature.sol
@@ -45,7 +45,6 @@ contract BatchFillNativeOrdersFeature is IFeature, IBatchFillNativeOrdersFeature
     uint256 public immutable override FEATURE_VERSION = _encodeVersion(1, 1, 0);
 
     constructor(address zeroExAddress) public FixinEIP712(zeroExAddress) {
-        // solhint-disable no-empty-blocks
     }
 
     /// @dev Initialize and register this feature.

--- a/contracts/zero-ex/contracts/src/features/BootstrapFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/BootstrapFeature.sol
@@ -27,7 +27,6 @@ import "./interfaces/IBootstrapFeature.sol";
 
 /// @dev Detachable `bootstrap()` feature.
 contract BootstrapFeature is IBootstrapFeature {
-    // solhint-disable state-visibility,indent
     /// @dev The ZeroEx contract.
     ///      This has to be immutable to persist across delegatecalls.
     address private immutable _deployer;
@@ -37,7 +36,6 @@ contract BootstrapFeature is IBootstrapFeature {
     /// @dev The deployer.
     ///      This has to be immutable to persist across delegatecalls.
     address private immutable _bootstrapCaller;
-    // solhint-enable state-visibility,indent
 
     using LibRichErrorsV06 for bytes;
 

--- a/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
@@ -114,7 +114,6 @@ contract MetaTransactionsFeature is
     }
 
     constructor(address zeroExAddress) public FixinCommon() FixinEIP712(zeroExAddress) {
-        // solhint-disable-next-line no-empty-blocks
     }
 
     /// @dev Initialize and register this feature.

--- a/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
@@ -113,8 +113,7 @@ contract MetaTransactionsFeature is
         require(initialBalance <= address(this).balance, "MetaTransactionsFeature/ETH_LEAK");
     }
 
-    constructor(address zeroExAddress) public FixinCommon() FixinEIP712(zeroExAddress) {
-    }
+    constructor(address zeroExAddress) public FixinCommon() FixinEIP712(zeroExAddress) {}
 
     /// @dev Initialize and register this feature.
     ///      Should be delegatecalled by `Migrate.migrate()`.

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -39,7 +39,6 @@ contract NativeOrdersFeature is IFeature, NativeOrdersSettlement {
         FeeCollectorController feeCollectorController,
         uint32 protocolFeeMultiplier
     ) public NativeOrdersSettlement(zeroExAddress, weth, staking, feeCollectorController, protocolFeeMultiplier) {
-        // solhint-disable no-empty-blocks
     }
 
     /// @dev Initialize and register this feature.

--- a/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/NativeOrdersFeature.sol
@@ -38,8 +38,7 @@ contract NativeOrdersFeature is IFeature, NativeOrdersSettlement {
         IStaking staking,
         FeeCollectorController feeCollectorController,
         uint32 protocolFeeMultiplier
-    ) public NativeOrdersSettlement(zeroExAddress, weth, staking, feeCollectorController, protocolFeeMultiplier) {
-    }
+    ) public NativeOrdersSettlement(zeroExAddress, weth, staking, feeCollectorController, protocolFeeMultiplier) {}
 
     /// @dev Initialize and register this feature.
     ///      Should be delegatecalled by `Migrate.migrate()`.

--- a/contracts/zero-ex/contracts/src/features/interfaces/IFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IFeature.sol
@@ -22,7 +22,6 @@ pragma experimental ABIEncoderV2;
 
 /// @dev Basic interface for a feature contract.
 interface IFeature {
-
     /// @dev The name of this feature set.
     function FEATURE_NAME() external view returns (string memory name);
 

--- a/contracts/zero-ex/contracts/src/features/interfaces/IFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IFeature.sol
@@ -22,7 +22,6 @@ pragma experimental ABIEncoderV2;
 
 /// @dev Basic interface for a feature contract.
 interface IFeature {
-    // solhint-disable func-name-mixedcase
 
     /// @dev The name of this feature set.
     function FEATURE_NAME() external view returns (string memory name);

--- a/contracts/zero-ex/contracts/src/features/interfaces/IOwnableFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IOwnableFeature.sol
@@ -22,7 +22,6 @@ pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-utils/contracts/src/v06/interfaces/IOwnableV06.sol";
 
-// solhint-disable no-empty-blocks
 /// @dev Owner management and migration features.
 interface IOwnableFeature is IOwnableV06 {
     /// @dev Emitted when `migrate()` is called.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersCancellation.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersCancellation.sol
@@ -36,8 +36,7 @@ abstract contract NativeOrdersCancellation is INativeOrdersEvents, NativeOrdersI
     /// @dev Highest bit of a uint256, used to flag cancelled orders.
     uint256 private constant HIGH_BIT = 1 << 255;
 
-    constructor(address zeroExAddress) internal NativeOrdersInfo(zeroExAddress) {
-    }
+    constructor(address zeroExAddress) internal NativeOrdersInfo(zeroExAddress) {}
 
     /// @dev Cancel a single limit order. The caller must be the maker or a valid order signer.
     ///      Silently succeeds if the order has already been cancelled.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersCancellation.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersCancellation.sol
@@ -37,7 +37,6 @@ abstract contract NativeOrdersCancellation is INativeOrdersEvents, NativeOrdersI
     uint256 private constant HIGH_BIT = 1 << 255;
 
     constructor(address zeroExAddress) internal NativeOrdersInfo(zeroExAddress) {
-        // solhint-disable no-empty-blocks
     }
 
     /// @dev Cancel a single limit order. The caller must be the maker or a valid order signer.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol
@@ -46,8 +46,7 @@ abstract contract NativeOrdersInfo is FixinEIP712, FixinTokenSpender {
     /// @dev Highest bit of a uint256, used to flag cancelled orders.
     uint256 private constant HIGH_BIT = 1 << 255;
 
-    constructor(address zeroExAddress) internal FixinEIP712(zeroExAddress) {
-    }
+    constructor(address zeroExAddress) internal FixinEIP712(zeroExAddress) {}
 
     /// @dev Get the order info for a limit order.
     /// @param order The limit order.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol
@@ -47,7 +47,6 @@ abstract contract NativeOrdersInfo is FixinEIP712, FixinTokenSpender {
     uint256 private constant HIGH_BIT = 1 << 255;
 
     constructor(address zeroExAddress) internal FixinEIP712(zeroExAddress) {
-        // solhint-disable no-empty-blocks
     }
 
     /// @dev Get the order info for a limit order.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersProtocolFees.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersProtocolFees.sol
@@ -38,7 +38,6 @@ abstract contract NativeOrdersProtocolFees is FixinProtocolFees {
         FeeCollectorController feeCollectorController,
         uint32 protocolFeeMultiplier
     ) internal FixinProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier) {
-        // solhint-disable no-empty-blocks
     }
 
     /// @dev Transfers protocol fees from the `FeeCollector` pools into

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersProtocolFees.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersProtocolFees.sol
@@ -37,8 +37,7 @@ abstract contract NativeOrdersProtocolFees is FixinProtocolFees {
         IStaking staking,
         FeeCollectorController feeCollectorController,
         uint32 protocolFeeMultiplier
-    ) internal FixinProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier) {
-    }
+    ) internal FixinProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier) {}
 
     /// @dev Transfers protocol fees from the `FeeCollector` pools into
     ///      the staking contract.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
@@ -119,7 +119,6 @@ abstract contract NativeOrdersSettlement is
         NativeOrdersCancellation(zeroExAddress)
         NativeOrdersProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier)
     {
-        // solhint-disable no-empty-blocks
     }
 
     /// @dev Fill a limit order. The taker and sender will be the caller.

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
@@ -118,8 +118,7 @@ abstract contract NativeOrdersSettlement is
         public
         NativeOrdersCancellation(zeroExAddress)
         NativeOrdersProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier)
-    {
-    }
+    {}
 
     /// @dev Fill a limit order. The taker and sender will be the caller.
     /// @param order The limit order. ETH protocol fees can be

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
@@ -500,6 +500,7 @@ abstract contract NativeOrdersSettlement is
         }
 
         // Update filled state for the order.
+        // solhint-disable-next-line max-line-length
         LibNativeOrdersStorage.getStorage().orderHashToTakerTokenFilledAmount[settleInfo.orderHash] = settleInfo // function if the order is cancelled. // OK to overwrite the whole word because we shouldn't get to this
             .takerTokenFilledAmount
             .safeAdd128(takerTokenFilledAmount);

--- a/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
+++ b/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
@@ -30,7 +30,6 @@ import "./InitialMigration.sol";
 
 /// @dev A contract for deploying and configuring the full ZeroEx contract.
 contract FullMigration {
-    // solhint-disable no-empty-blocks,indent
 
     /// @dev Features to add the the proxy contract.
     struct Features {

--- a/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
+++ b/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
@@ -30,7 +30,6 @@ import "./InitialMigration.sol";
 
 /// @dev A contract for deploying and configuring the full ZeroEx contract.
 contract FullMigration {
-
     /// @dev Features to add the the proxy contract.
     struct Features {
         SimpleFunctionRegistryFeature registry;

--- a/contracts/zero-ex/contracts/src/storage/LibERC1155OrdersStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibERC1155OrdersStorage.sol
@@ -43,8 +43,8 @@ library LibERC1155OrdersStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.ERC1155Orders);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibERC721OrdersStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibERC721OrdersStorage.sol
@@ -35,8 +35,8 @@ library LibERC721OrdersStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.ERC721Orders);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibMetaTransactionsStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibMetaTransactionsStorage.sol
@@ -33,8 +33,8 @@ library LibMetaTransactionsStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.MetaTransactions);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibNativeOrdersStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibNativeOrdersStorage.sol
@@ -30,14 +30,13 @@ library LibNativeOrdersStorage {
         // The lower `uint128` is the taker token fill amount.
         // The high bit will be `1` if the order was directly cancelled.
         mapping(bytes32 => uint256) orderHashToTakerTokenFilledAmount;
-        // The minimum valid order salt for a given maker and order pair (maker, taker)
-        // for limit orders.
-        mapping(address => mapping(address => mapping(address => uint256))) limitOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
-        // The minimum valid order salt for a given maker and order pair (maker, taker)
-        // for RFQ orders.
-        mapping(address => mapping(address => mapping(address => uint256))) rfqOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
-        // For a given order origin, which tx.origin addresses are allowed to
-        // fill the order.
+        // The minimum valid order salt for a given maker and order pair (maker, taker) for limit orders.
+        mapping(address => mapping(address => mapping(address => uint256)))
+            limitOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
+        // The minimum valid order salt for a given maker and order pair (maker, taker) for RFQ orders.
+        mapping(address => mapping(address => mapping(address => uint256)))
+            rfqOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
+        // For a given order origin, which tx.origin addresses are allowed to fill the order.
         mapping(address => mapping(address => bool)) originRegistry;
         // For a given maker address, which addresses are allowed to
         // sign on its behalf.
@@ -47,8 +46,8 @@ library LibNativeOrdersStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.NativeOrders);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibNativeOrdersStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibNativeOrdersStorage.sol
@@ -31,11 +31,11 @@ library LibNativeOrdersStorage {
         // The high bit will be `1` if the order was directly cancelled.
         mapping(bytes32 => uint256) orderHashToTakerTokenFilledAmount;
         // The minimum valid order salt for a given maker and order pair (maker, taker) for limit orders.
-        mapping(address => mapping(address => mapping(address => uint256)))
-            limitOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
+        // solhint-disable-next-line max-line-length
+        mapping(address => mapping(address => mapping(address => uint256))) limitOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
         // The minimum valid order salt for a given maker and order pair (maker, taker) for RFQ orders.
-        mapping(address => mapping(address => mapping(address => uint256)))
-            rfqOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
+        // solhint-disable-next-line max-line-length
+        mapping(address => mapping(address => mapping(address => uint256))) rfqOrdersMakerToMakerTokenToTakerTokenToMinValidOrderSalt;
         // For a given order origin, which tx.origin addresses are allowed to fill the order.
         mapping(address => mapping(address => bool)) originRegistry;
         // For a given maker address, which addresses are allowed to

--- a/contracts/zero-ex/contracts/src/storage/LibOtcOrdersStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibOtcOrdersStorage.sol
@@ -33,8 +33,8 @@ library LibOtcOrdersStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.OtcOrders);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibOwnableStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibOwnableStorage.sol
@@ -35,6 +35,7 @@ library LibOwnableStorage {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.Ownable);
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibProxyStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibProxyStorage.sol
@@ -35,8 +35,8 @@ library LibProxyStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.Proxy);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibReentrancyGuardStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibReentrancyGuardStorage.sol
@@ -27,16 +27,15 @@ import "../external/IFlashWallet.sol";
 library LibReentrancyGuardStorage {
     /// @dev Storage bucket for this feature.
     struct Storage {
-        // Reentrancy flags set whenever a non-reentrant function is entered
-        // and cleared when it is exited.
+        // Reentrancy flags set whenever a non-reentrant function is entered and cleared when it is exited.
         uint256 reentrancyFlags;
     }
 
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.ReentrancyGuard);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibSimpleFunctionRegistryStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibSimpleFunctionRegistryStorage.sol
@@ -33,8 +33,8 @@ library LibSimpleFunctionRegistryStorage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.SimpleFunctionRegistry);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/storage/LibStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibStorage.sol
@@ -23,11 +23,11 @@ pragma experimental ABIEncoderV2;
 /// @dev Common storage helpers
 library LibStorage {
     /// @dev What to bit-shift a storage ID by to get its slot.
-    ///      This gives us a maximum of 2**128 inline fields in each bucket.
+    /// This gives us a maximum of 2**128 inline fields in each bucket.
     uint256 private constant STORAGE_SLOT_EXP = 128;
 
     /// @dev Storage IDs for feature storage buckets.
-    ///      WARNING: APPEND-ONLY.
+    /// WARNING: APPEND-ONLY.
     enum StorageId {
         Proxy,
         SimpleFunctionRegistry,
@@ -42,9 +42,10 @@ library LibStorage {
         ERC1155Orders
     }
 
-    /// @dev Get the storage slot given a storage ID. We assign unique, well-spaced
-    ///     slots to storage bucket variables to ensure they do not overlap.
-    ///     See: https://solidity.readthedocs.io/en/v0.6.6/assembly.html#access-to-external-variables-functions-and-libraries
+    /// @dev Get the storage slot given a storage ID. We assign unique, well-spaced slots to storage bucket variables
+    /// to ensure they do not overlap.
+    // solhint-disable-next-line max-line-length
+    /// See: https://solidity.readthedocs.io/en/v0.6.6/assembly.html#access-to-external-variables-functions-and-libraries
     /// @param storageId An entry in `StorageId`
     /// @return slot The storage slot.
     function getStorageSlot(StorageId storageId) internal pure returns (uint256 slot) {

--- a/contracts/zero-ex/contracts/src/storage/LibTransformERC20Storage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibTransformERC20Storage.sol
@@ -38,8 +38,8 @@ library LibTransformERC20Storage {
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
         uint256 storageSlot = LibStorage.getStorageSlot(LibStorage.StorageId.TransformERC20);
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
+        // Dip into assembly to change the slot pointed to by the local variable `stor`.
+        // solhint-disable-next-line max-line-length
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
         assembly {
             stor_slot := storageSlot

--- a/contracts/zero-ex/contracts/src/transformers/PayTakerTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/PayTakerTransformer.sol
@@ -30,7 +30,6 @@ import "./LibERC20Transformer.sol";
 
 /// @dev A transformer that transfers tokens to the taker.
 contract PayTakerTransformer is Transformer {
-    // solhint-disable no-empty-blocks
     using LibRichErrorsV06 for bytes;
     using LibSafeMathV06 for uint256;
     using LibERC20Transformer for IERC20TokenV06;

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinBalancerV2.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinBalancerV2.sol
@@ -29,6 +29,7 @@ interface IBalancerV2Vault {
         GIVEN_OUT
     }
 
+    // solhint-disable max-line-length
     /**
      * @dev Performs a swap with a single Pool.
      *
@@ -41,8 +42,11 @@ interface IBalancerV2Vault {
      * Internal Balance usage and the recipient are determined by the `funds` struct.
      *
      * Emits a `Swap` event.
-     * For full documentation see https://github.com/balancer-labs/balancer-core-v2/blob/master/contracts/vault/interfaces/IVault.sol // solhint-disable-line max-line-length
+     * For full documentation see https://github.com/balancer-labs/balancer-core-v2/blob/master/contracts/vault/interfaces/IVault.sol
      */
+
+    // solhint-enable max-line-length
+
     function swap(
         SingleSwap calldata request,
         FundManagement calldata funds,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinBalancerV2.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinBalancerV2.sol
@@ -41,7 +41,7 @@ interface IBalancerV2Vault {
      * Internal Balance usage and the recipient are determined by the `funds` struct.
      *
      * Emits a `Swap` event.
-     * For full documentation see https://github.com/balancer-labs/balancer-core-v2/blob/master/contracts/vault/interfaces/IVault.sol
+     * For full documentation see https://github.com/balancer-labs/balancer-core-v2/blob/master/contracts/vault/interfaces/IVault.sol // solhint-disable-line max-line-length
      */
     function swap(
         SingleSwap calldata request,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinGMX.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinGMX.sol
@@ -32,7 +32,7 @@ interface IGmxRouter {
     /// must exist and have liquidity.
     /// @param _amountIn The amount of input tokens to send.
     /// @param _minOut The minimum amount of output tokens that must be received for the transaction not to revert.
-    /// @param _reciever Recipient of the output tokens.
+    /// @param _receiver Recipient of the output tokens.
     function swap(
         address[] calldata _path,
         uint256 _amountIn,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinGMX.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinGMX.sol
@@ -25,13 +25,14 @@ import "../IBridgeAdapter.sol";
     UniswapV2
 */
 interface IGmxRouter {
-    // /// @dev Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by the path.
-    // ///      The first element of path is the input token, the last is the output token, and any intermediate elements represent
-    // ///      intermediate pairs to trade through (if, for example, a direct pair does not exist).
-    // /// @param _path An array of token addresses. path.length must be >= 2. Pools for each consecutive pair of addresses must exist and have liquidity.
-    // /// @param _amountIn The amount of input tokens to send.
-    // /// @param _minOut The minimum amount of output tokens that must be received for the transaction not to revert.
-    // /// @param _reciever Recipient of the output tokens.
+    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by
+    /// the path. The first element of path is the input token, the last is the output token, and any intermediate
+    /// elements represent intermediate pairs to trade through (if, for example, a direct pair does not exist).
+    /// @param _path An array of token addresses. path.length must be >= 2. Pools for each consecutive pair of addresses
+    /// must exist and have liquidity.
+    /// @param _amountIn The amount of input tokens to send.
+    /// @param _minOut The minimum amount of output tokens that must be received for the transaction not to revert.
+    /// @param _reciever Recipient of the output tokens.
     function swap(
         address[] calldata _path,
         uint256 _amountIn,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinKyberDmm.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinKyberDmm.sol
@@ -29,13 +29,14 @@ import "../IBridgeAdapter.sol";
     KyberDmm Router
 */
 interface IKyberDmmRouter {
-    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by the path.
-    ///      The first element of path is the input token, the last is the output token, and any intermediate elements represent
-    ///      intermediate pairs to trade through (if, for example, a direct pair does not exist).
+    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by
+    /// the path. The first element of path is the input token, the last is the output token, and any intermediate
+    /// elements represent intermediate pairs to trade through (if, for example, a direct pair does not exist).
     /// @param amountIn The amount of input tokens to send.
     /// @param amountOutMin The minimum amount of output tokens that must be received for the transaction not to revert.
     /// @param pools An array of pool addresses. pools.length must be >= 1.
-    /// @param path An array of token addresses. path.length must be >= 2. Pools for each consecutive pair of addresses must exist and have liquidity.
+    /// @param path An array of token addresses. path.length must be >= 2. Pools for each consecutive pair of addresses
+    /// must exist and have liquidity.
     /// @param to Recipient of the output tokens.
     /// @param deadline Unix timestamp after which the transaction will revert.
     /// @return amounts The input token amount and all subsequent output token amounts.

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinSynthetix.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinSynthetix.sol
@@ -41,7 +41,9 @@ interface ISynthetix {
 }
 
 contract MixinSynthetix {
+    // solhint-disable-next-line const-name-snakecase
     address private constant rewardAddress = 0x5C80239D97E1eB216b5c3D8fBa5DE5Be5d38e4C9;
+    // solhint-disable-next-line const-name-snakecase
     bytes32 constant trackingCode = 0x3058000000000000000000000000000000000000000000000000000000000000;
 
     function _tradeSynthetix(uint256 sellAmount, bytes memory bridgeData) public returns (uint256 boughtAmount) {

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinUniswapV2.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinUniswapV2.sol
@@ -29,12 +29,13 @@ import "../IBridgeAdapter.sol";
     UniswapV2
 */
 interface IUniswapV2Router02 {
-    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by the path.
-    ///      The first element of path is the input token, the last is the output token, and any intermediate elements represent
-    ///      intermediate pairs to trade through (if, for example, a direct pair does not exist).
+    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by
+    /// the path. The first element of path is the input token, the last is the output token, and any intermediate
+    /// elements represent intermediate pairs to trade through (if, for example, a direct pair does not exist).
     /// @param amountIn The amount of input tokens to send.
     /// @param amountOutMin The minimum amount of output tokens that must be received for the transaction not to revert.
-    /// @param path An array of token addresses. path.length must be >= 2. Pools for each consecutive pair of addresses must exist and have liquidity.
+    /// @param path An array of token addresses. path.length must be >= 2. Pools for each consecutive pair of addresses
+    /// must exist and have liquidity.
     /// @param to Recipient of the output tokens.
     /// @param deadline Unix timestamp after which the transaction will revert.
     /// @return amounts The input token amount and all subsequent output token amounts.

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinWOOFi.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinWOOFi.sol
@@ -54,15 +54,17 @@ contract MixinWOOFi {
     using LibERC20TokenV06 for IEtherTokenV06;
     using LibSafeMathV06 for uint256;
 
+    // solhint-disable-next-line const-name-snakecase
     address constant rebateAddress = 0xBfdcBB4C05843163F491C24f9c0019c510786304;
 
-    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible.
-    /// @param _amountIn Amount of input tokens to send
-    /// @param _minAmountOut The minimum amount of output tokens that must be received for the transaction not to revert
-    /// @param _tokenIn Input token
-    /// @param _tokenOut Output token
-    /// @param _to recipient of tokens
-    /// @param pool WOOFi pool where the swap will happen
+    // /// @dev Swaps an exact amount of input tokens for as many output tokens as possible.
+    // /// @param _amountIn Amount of input tokens to send
+    // /// @param _minAmountOut The minimum amount of output tokens that must be received for the transaction
+    // /// not to revert
+    // /// @param _tokenIn Input token
+    // /// @param _tokenOut Output token
+    // /// @param _to recipient of tokens
+    // /// @param pool WOOFi pool where the swap will happen
     function _tradeWOOFi(
         IERC20TokenV06 sellToken,
         IERC20TokenV06 buyToken,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinWOOFi.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinWOOFi.sol
@@ -56,13 +56,13 @@ contract MixinWOOFi {
 
     address constant rebateAddress = 0xBfdcBB4C05843163F491C24f9c0019c510786304;
 
-    // /// @dev Swaps an exact amount of input tokens for as many output tokens as possible.
-    // /// @param _amountIn Amount of input tokens to send
-    // /// @param _minAmountOut The minimum amount of output tokens that must be received for the transaction not to revert.
-    // /// @param _tokenIn Input token
-    // /// @param _tokenOut Output token
-    // /// @param _to recipient of tokens
-    // /// @param pool WOOFi pool where the swap will happen
+    /// @dev Swaps an exact amount of input tokens for as many output tokens as possible.
+    /// @param _amountIn Amount of input tokens to send
+    /// @param _minAmountOut The minimum amount of output tokens that must be received for the transaction not to revert
+    /// @param _tokenIn Input token
+    /// @param _tokenOut Output token
+    /// @param _to recipient of tokens
+    /// @param pool WOOFi pool where the swap will happen
     function _tradeWOOFi(
         IERC20TokenV06 sellToken,
         IERC20TokenV06 buyToken,

--- a/contracts/zero-ex/contracts/src/vendor/IUniswapV3Pool.sol
+++ b/contracts/zero-ex/contracts/src/vendor/IUniswapV3Pool.sol
@@ -24,7 +24,8 @@ interface IUniswapV3Pool {
     /// @dev The caller of this method receives a callback in the form of IUniswapV3SwapCallback#uniswapV3SwapCallback
     /// @param recipient The address to receive the output of the swap
     /// @param zeroForOne The direction of the swap, true for token0 to token1, false for token1 to token0
-    /// @param amountSpecified The amount of the swap, which implicitly configures the swap as exact input (positive), or exact output (negative)
+    /// @param amountSpecified The amount of the swap, which implicitly configures the swap as exact input (positive),
+    /// or exact output (negative)
     /// @param sqrtPriceLimitX96 The Q64.96 sqrt price limit. If zero for one, the price cannot be less than this
     /// value after the swap. If one for zero, the price cannot be greater than this value after the swap
     /// @param data Any data to be passed through to the callback

--- a/contracts/zero-ex/contracts/test/TestFixinProtocolFees.sol
+++ b/contracts/zero-ex/contracts/test/TestFixinProtocolFees.sol
@@ -28,8 +28,7 @@ contract TestFixinProtocolFees is FixinProtocolFees {
         IStaking staking,
         FeeCollectorController feeCollectorController,
         uint32 protocolFeeMultiplier
-    ) public FixinProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier) {
-    }
+    ) public FixinProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier) {}
 
     function collectProtocolFee(bytes32 poolId) external payable {
         _collectProtocolFee(poolId);

--- a/contracts/zero-ex/contracts/test/TestFixinProtocolFees.sol
+++ b/contracts/zero-ex/contracts/test/TestFixinProtocolFees.sol
@@ -29,7 +29,6 @@ contract TestFixinProtocolFees is FixinProtocolFees {
         FeeCollectorController feeCollectorController,
         uint32 protocolFeeMultiplier
     ) public FixinProtocolFees(weth, staking, feeCollectorController, protocolFeeMultiplier) {
-        // solhint-disalbe no-empty-blocks
     }
 
     function collectProtocolFee(bytes32 poolId) external payable {

--- a/contracts/zero-ex/contracts/test/TestFullMigration.sol
+++ b/contracts/zero-ex/contracts/test/TestFullMigration.sol
@@ -26,7 +26,6 @@ import "../src/migrations/FullMigration.sol";
 contract TestFullMigration is FullMigration {
     address public dieRecipient;
 
-    // solhint-disable-next-line no-empty-blocks
     constructor(address payable deployer) public FullMigration(deployer) {}
 
     function die(address payable ethRecipient) external override {

--- a/contracts/zero-ex/contracts/test/TestInitialMigration.sol
+++ b/contracts/zero-ex/contracts/test/TestInitialMigration.sol
@@ -28,7 +28,6 @@ contract TestInitialMigration is InitialMigration {
     address public bootstrapFeature;
     address public dieRecipient;
 
-    // solhint-disable-next-line no-empty-blocks
     constructor(address deployer) public InitialMigration(deployer) {}
 
     function callBootstrap(ZeroEx zeroEx) external {

--- a/contracts/zero-ex/contracts/test/TestNativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/test/TestNativeOrdersFeature.sol
@@ -21,8 +21,7 @@ contract TestNativeOrdersFeature is NativeOrdersFeature {
             FeeCollectorController(address(new TestFeeCollectorController())),
             protocolFeeMultiplier
         )
-    {
-    }
+    {}
 
     modifier onlySelf() override {
         _;

--- a/contracts/zero-ex/contracts/test/TestNativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/test/TestNativeOrdersFeature.sol
@@ -22,7 +22,6 @@ contract TestNativeOrdersFeature is NativeOrdersFeature {
             protocolFeeMultiplier
         )
     {
-        // solhint-disable no-empty-blocks
     }
 
     modifier onlySelf() override {

--- a/contracts/zero-ex/contracts/test/TestTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerHost.sol
@@ -44,7 +44,5 @@ contract TestTransformerHost {
         );
     }
 
-    // solhint-disable
     receive() external payable {}
-    // solhint-enable
 }

--- a/contracts/zero-ex/contracts/test/TestWethTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestWethTransformerHost.sol
@@ -26,10 +26,7 @@ import "./TestTransformerHost.sol";
 import "./tokens/TestWeth.sol";
 
 contract TestWethTransformerHost is TestTransformerHost {
-    // solhint-disable
     TestWeth private immutable _weth;
-
-    // solhint-enable
 
     constructor(TestWeth weth) public {
         _weth = weth;

--- a/contracts/zero-ex/contracts/test/TestZeroExFeature.sol
+++ b/contracts/zero-ex/contracts/test/TestZeroExFeature.sol
@@ -35,7 +35,6 @@ contract TestZeroExFeature is FixinCommon {
         emit NotPayableFnCalled();
     }
 
-    // solhint-disable no-empty-blocks
     function unimplmentedFn() external {}
 
     function internalFn() external onlySelf {}

--- a/docs/architecture/features.rst
+++ b/docs/architecture/features.rst
@@ -42,8 +42,6 @@ The only requirement is that the Feature implements the interface in `IFeature <
     /// @dev Basic interface for a feature contract.
     interface IFeature {
 
-        // solhint-disable func-name-mixedcase
-
         /// @dev The name of this feature set.
         function FEATURE_NAME() external view returns (string memory name);
 
@@ -70,7 +68,7 @@ We use this checklist to review the safety of new Features.
     - [ ] No direct access to another feature’s storage bucket without strong justification.
     - [ ] No executing arbitrary calldata from the context of the Exchange Proxy.
     - [ ] No external calls to arbitrary contracts from within the Exchange Proxy.
-    - [ ] Features use unique StorageIds. 
+    - [ ] Features use unique StorageIds.
     - [ ] Document functions with execution contexts outside of the Exchange Proxy.
     - [ ] Document feature dependencies in checklist doc.
     - [ ] Document reentrant functions in checklist doc.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "watch:ts": "tsc -b -w",
         "clean": "wsrun --fast-exit -r --parallel --exclude-missing -p $PKG -c clean",
         "contracts:watch": "wsrun --parallel --exclude-missing -p $PKG -c watch",
+        "lint:contracts": "npx solhint contracts/**/*.sol",
         "remove_node_modules": "lerna clean --yes; rm -rf node_modules",
         "rebuild": "run-s clean build",
         "test": "wsrun --fast-exit --serial --exclude-missing -p $(echo $(echo ${npm_package_config_contractsPackages} ${npm_package_config_nonContractPackages} | tr ' ' '\n' | sort | uniq) ${npm_package_config_ignoreTestsForPackages} | tr ' ' '\n' | sort | uniq -u | tr '\n' ' ') -c test",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "prettier": "2.7.1",
         "prettier-plugin-solidity": "^1.0.0-beta.24",
         "solhint": "^3.3.7",
+        "solhint-plugin-prettier": "^0.0.5",
         "source-map-support": "^0.5.6",
         "typescript": "4.6.3",
         "wsrun": "^5.2.4"

--- a/package.json
+++ b/package.json
@@ -71,11 +71,13 @@
         "npm-run-all": "^4.1.2",
         "prettier": "2.7.1",
         "prettier-plugin-solidity": "^1.0.0-beta.24",
+        "solhint": "^3.3.7",
         "source-map-support": "^0.5.6",
         "typescript": "4.6.3",
         "wsrun": "^5.2.4"
     },
     "resolutions": {
         "**/bignumber.js": "^9.0.2"
-    }
+    },
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "diff_md_docs:ci": "wsrun --exclude-missing -c diff_docs",
         "test:generate_docs:circleci": "for i in ${npm_package_config_packagesWithDocPages}; do yarn generate_doc --package $i || break -1; done;",
         "bundlewatch": "bundlewatch",
-        "lint": "wsrun --fast-exit --parallel --exclude-missing -p $PKG -c lint",
+        "lint:ts": "wsrun --fast-exit --parallel --exclude-missing -p $PKG -c lint",
+        "lint": "yarn lint:ts && yarn lint:contracts",
         "upgrade_tools": "node node_modules/@0x/monorepo-scripts/lib/upgrade_deps.js -p '@0x/abi-gen|@0x/assert|@0x/base-contract|@0x/contracts-gen|@0x/dev-utils|@0x/json-schemas|@0x/monorepo-scripts|@0x/sol-compiler|@0x/sol-coverage|@0x/sol-doc|@0x/sol-profiler|@0x/sol-resolver|@0x/sol-trace|@0x/sol-tracing-utils|@0x/subproviders|@0x/tslint-config|@0x/types|@0x/typescript-typings|@0x/utils|@0x/verdaccio|@0x/web3-wrapper|ethereum-types'",
         "upgrade_deps": "node node_modules/@0x/monorepo-scripts/lib/upgrade_deps.js",
         "verdaccio": "docker run --rm -i -p 4873:4873 0xorg/verdaccio"

--- a/packages/asset-swapper/contracts/src/CurveSampler.sol
+++ b/packages/asset-swapper/contracts/src/CurveSampler.sol
@@ -155,7 +155,7 @@ contract CurveSampler is
         if (!success) {
             return 0;
         }
-        // solhint-disable-next-line indent
+
         return abi.decode(resultData, (uint256[]))[0];
     }
 }

--- a/packages/asset-swapper/contracts/src/GMXSampler.sol
+++ b/packages/asset-swapper/contracts/src/GMXSampler.sol
@@ -89,7 +89,7 @@ contract GMXSampler is
         if(!success) {
             return 0;
         }
-        // solhint-disable-next-line indent
+
         return abi.decode(resultData, (uint256[]))[0];
     }
 

--- a/packages/asset-swapper/contracts/src/PlatypusSampler.sol
+++ b/packages/asset-swapper/contracts/src/PlatypusSampler.sol
@@ -83,7 +83,7 @@ contract PlatypusSampler is
         if(!success) {
             return 0;
         }
-        // solhint-disable-next-line indent
+
         return abi.decode(resultData, (uint256[]))[0];
     }
 }

--- a/packages/asset-swapper/contracts/src/interfaces/ICurve.sol
+++ b/packages/asset-swapper/contracts/src/interfaces/ICurve.sol
@@ -19,8 +19,6 @@
 
 pragma solidity ^0.6;
 
-
-// solhint-disable func-name-mixedcase
 interface ICurve {
 
     /// @dev Sell `sellAmount` of `fromToken` token and receive `toToken` token.

--- a/yarn.lock
+++ b/yarn.lock
@@ -14155,6 +14155,13 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 prettier-plugin-solidity@^1.0.0-beta.24:
   version "1.0.0-beta.24"
   resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.24.tgz#67573ca87098c14f7ccff3639ddd8a4cab2a87eb"
@@ -15661,6 +15668,13 @@ solc@^0.8:
     memorystream "^0.3.1"
     semver "^5.5.0"
     tmp "0.0.33"
+
+solhint-plugin-prettier@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/solhint-plugin-prettier/-/solhint-plugin-prettier-0.0.5.tgz#e3b22800ba435cd640a9eca805a7f8bc3e3e6a6b"
+  integrity sha512-7jmWcnVshIrO2FFinIvDQmhQpfpS2rRRn3RejiYgnjIE68xO2bvrYvjqVNfrio4xH9ghOqn83tKuTzLjEbmGIA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 solhint@^3.3.7:
   version "3.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3359,6 +3359,13 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
+"@solidity-parser/parser@^0.14.1":
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
+  integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
 "@solidity-parser/parser@^0.14.3":
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.3.tgz#0d627427b35a40d8521aaa933cc3df7d07bfa36f"
@@ -4138,10 +4145,15 @@ accepts@^1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-jsx@^5.3.2:
+acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn@^6.0.7:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
 acorn@^8.8.0:
   version "8.8.0"
@@ -4193,7 +4205,7 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.6.1, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4283,6 +4295,11 @@ ansi@^0.3.0, ansi@~0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ansi/-/ansi-0.3.1.tgz#0c42d4fb17160d5a9af1e484bace1c66922c1b21"
   integrity sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==
+
+antlr4@4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.1.tgz#69984014f096e9e775f53dd9744bf994d8959773"
+  integrity sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==
 
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"
@@ -4604,6 +4621,16 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
+
+ast-parents@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/ast-parents/-/ast-parents-0.0.1.tgz#508fd0f05d0c48775d9eccda2e174423261e8dd3"
+  integrity sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-child-process@^1.1.1:
   version "1.1.1"
@@ -6390,6 +6417,11 @@ command-line-usage@^6.1.0:
     table-layout "^1.0.2"
     typical "^5.2.0"
 
+commander@2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+  integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
+
 commander@^2.12.1, commander@^2.20.3, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -6663,7 +6695,7 @@ cors@^2.8.1, cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.1.0:
+cosmiconfig@^5.0.7, cosmiconfig@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -6903,7 +6935,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@^4.0.1, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -7660,6 +7692,14 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
+eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -7676,12 +7716,24 @@ eslint-scope@^7.1.1:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
+eslint-utils@^1.3.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-utils@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
   integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
     eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0:
   version "2.1.0"
@@ -7692,6 +7744,48 @@ eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint@^5.6.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
+  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    js-yaml "^3.13.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
 
 eslint@^8.23.1:
   version "8.23.1"
@@ -7738,6 +7832,15 @@ eslint@^8.23.1:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
+
 espree@^9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.0.tgz#cd4bc3d6e9336c433265fc0aa016fc1aaf182f8a"
@@ -7757,14 +7860,14 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0:
+esquery@^1.0.1, esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.3.0:
+esrecurse@^4.1.0, esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
@@ -8565,6 +8668,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -8649,6 +8757,13 @@ figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -8790,6 +8905,15 @@ find-yarn-workspace-root@^1.2.1:
     fs-extra "^4.0.3"
     micromatch "^3.1.4"
 
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -8809,6 +8933,11 @@ flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+flatted@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 flatted@^3.1.0:
   version "3.2.7"
@@ -9461,6 +9590,11 @@ global@~4.4.0:
     min-document "^2.19.0"
     process "^0.11.10"
 
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
 globals@^13.15.0:
   version "13.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
@@ -9931,7 +10065,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^4.0.3:
+ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
@@ -10049,7 +10183,7 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-inquirer@^6.2.0:
+inquirer@^6.2.0, inquirer@^6.2.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
   integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
@@ -10806,7 +10940,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@3.x, js-yaml@^3.13.1, js-yaml@^3.7.0:
+js-yaml@3.x, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -11361,6 +11495,14 @@ levelup@^1.2.1:
     semver "~5.4.1"
     xtend "~4.0.0"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -11368,14 +11510,6 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
-
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -13078,7 +13212,7 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -13489,7 +13623,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==
@@ -14038,7 +14172,7 @@ prettier@2.7.1, prettier@^2.3.1, prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
-prettier@^1.16.3:
+prettier@^1.14.3, prettier@^1.16.3:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
@@ -14074,7 +14208,7 @@ progress-stream@^1.0.1:
     speedometer "~0.1.2"
     through2 "~0.2.3"
 
-progress@^2.0.3:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -14703,6 +14837,11 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -14945,6 +15084,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
 
@@ -15431,6 +15577,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
+
 slide@^1.1.3, slide@^1.1.5, slide@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
@@ -15506,6 +15661,28 @@ solc@^0.8:
     memorystream "^0.3.1"
     semver "^5.5.0"
     tmp "0.0.33"
+
+solhint@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.7.tgz#b5da4fedf7a0fee954cb613b6c55a5a2b0063aa7"
+  integrity sha512-NjjjVmXI3ehKkb3aNtRJWw55SUVJ8HMKKodwe0HnejA+k0d2kmhw7jvpa+MCTbcEgt8IWSwx0Hu6aCo/iYOZzQ==
+  dependencies:
+    "@solidity-parser/parser" "^0.14.1"
+    ajv "^6.6.1"
+    antlr4 "4.7.1"
+    ast-parents "0.0.1"
+    chalk "^2.4.2"
+    commander "2.18.0"
+    cosmiconfig "^5.0.7"
+    eslint "^5.6.0"
+    fast-diff "^1.1.2"
+    glob "^7.1.3"
+    ignore "^4.0.6"
+    js-yaml "^3.12.0"
+    lodash "^4.17.11"
+    semver "^6.3.0"
+  optionalDependencies:
+    prettier "^1.14.3"
 
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"
@@ -15950,7 +16127,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
@@ -16081,6 +16258,16 @@ table-layout@^1.0.2:
     deep-extend "~0.6.0"
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
+
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tape@^4.4.0, tape@^4.6.3:
   version "4.16.0"
@@ -18301,6 +18488,13 @@ write-stream@~0.4.3:
   integrity sha512-IJrvkhbAnj89W/GAVdVgbnPiVw5Ntg/B4tc/MUCIEwj/g6JIww1DWJyB/yBMT3yw2/TkT6IUZ0+IYef3flEw8A==
   dependencies:
     readable-stream "~0.0.2"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@7.4.6:
   version "7.4.6"


### PR DESCRIPTION
## Description
Adds linter for Solidity contracts as this is necessary in addition to the prettier formatter we run. The [differences between linters and prettier are best described in prettier's docs](https://prettier.io/docs/en/comparison.html).

We add `solhint` linter and integrate with `prettier` to remove ambiguity on overlapping rules such as max-line-length and single/double quotes. 

Excluded from linting is the non upgradable token contract at `contracts/src/ZRXToken.sol`.

Note that this PR reverts the changes from https://github.com/0xProject/protocol/pull/593 which had removed `solhint` due to clashing rules between that and `prettier`. Here we circumvent that using `solhint-plugin-prettier` which allows us to run prettier via `solhint`.

Closes https://linear.app/0xproject/issue/GOV-5/add-solidity-linter

## Testing instructions

Run `lint:contracts`

## Types of changes

* Bug fix (non-breaking change which fixes an issue) 

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
