### PR TITLE
Upgrade prettier-plugin-solidity to stable v1

### DIFF
--- a/contracts/erc20/contracts/src/ERC20Token.sol
+++ b/contracts/erc20/contracts/src/ERC20Token.sol
@@ -47,11 +47,7 @@ contract ERC20Token is IERC20Token {
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return True if transfer was successful
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) external returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool) {
         require(balances[_from] >= _value, "ERC20_INSUFFICIENT_BALANCE");
         require(allowed[_from][msg.sender] >= _value, "ERC20_INSUFFICIENT_ALLOWANCE");
         require(balances[_to] + _value >= balances[_to], "UINT256_OVERFLOW");

--- a/contracts/erc20/contracts/src/LibERC20Token.sol
+++ b/contracts/erc20/contracts/src/LibERC20Token.sol
@@ -31,11 +31,7 @@ library LibERC20Token {
     /// @param token The address of the token contract.
     /// @param spender The address that receives an allowance.
     /// @param allowance The allowance to set.
-    function approve(
-        address token,
-        address spender,
-        uint256 allowance
-    ) internal {
+    function approve(address token, address spender, uint256 allowance) internal {
         bytes memory callData = abi.encodeWithSelector(IERC20Token(0).approve.selector, spender, allowance);
         _callWithOptionalBooleanResult(token, callData);
     }
@@ -47,11 +43,7 @@ library LibERC20Token {
     /// @param token The address of the token contract.
     /// @param spender The address that receives an allowance.
     /// @param amount The minimum allowance needed.
-    function approveIfBelow(
-        address token,
-        address spender,
-        uint256 amount
-    ) internal {
+    function approveIfBelow(address token, address spender, uint256 amount) internal {
         if (IERC20Token(token).allowance(address(this), spender) < amount) {
             approve(token, spender, uint256(-1));
         }
@@ -63,11 +55,7 @@ library LibERC20Token {
     /// @param token The address of the token contract.
     /// @param to The address that receives the tokens
     /// @param amount Number of tokens to transfer.
-    function transfer(
-        address token,
-        address to,
-        uint256 amount
-    ) internal {
+    function transfer(address token, address to, uint256 amount) internal {
         bytes memory callData = abi.encodeWithSelector(IERC20Token(0).transfer.selector, to, amount);
         _callWithOptionalBooleanResult(token, callData);
     }
@@ -79,12 +67,7 @@ library LibERC20Token {
     /// @param from The owner of the tokens.
     /// @param to The address that receives the tokens
     /// @param amount Number of tokens to transfer.
-    function transferFrom(
-        address token,
-        address from,
-        address to,
-        uint256 amount
-    ) internal {
+    function transferFrom(address token, address from, address to, uint256 amount) internal {
         bytes memory callData = abi.encodeWithSelector(IERC20Token(0).transferFrom.selector, from, to, amount);
         _callWithOptionalBooleanResult(token, callData);
     }
@@ -107,11 +90,7 @@ library LibERC20Token {
     /// @param owner The owner of the tokens.
     /// @param spender The address the spender.
     /// @return allowance The allowance for a token, owner, and spender.
-    function allowance(
-        address token,
-        address owner,
-        address spender
-    ) internal view returns (uint256 allowance_) {
+    function allowance(address token, address owner, address spender) internal view returns (uint256 allowance_) {
         (bool didSucceed, bytes memory resultData) = token.staticcall(
             abi.encodeWithSelector(IERC20Token(0).allowance.selector, owner, spender)
         );

--- a/contracts/erc20/contracts/src/UnlimitedAllowanceERC20Token.sol
+++ b/contracts/erc20/contracts/src/UnlimitedAllowanceERC20Token.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.5.9;
 import "./ERC20Token.sol";
 
 contract UnlimitedAllowanceERC20Token is ERC20Token {
-    uint256 internal constant MAX_UINT = 2**256 - 1;
+    uint256 internal constant MAX_UINT = 2 ** 256 - 1;
 
     /// @dev ERC20 transferFrom, modified such that an allowance of MAX_UINT represents an unlimited allowance.
     // See https://github.com/ethereum/EIPs/issues/717
@@ -29,11 +29,7 @@ contract UnlimitedAllowanceERC20Token is ERC20Token {
     /// @param _to Address to transfer to.
     /// @param _value Amount to transfer.
     /// @return Success of transfer.
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) external returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool) {
         uint256 allowance = allowed[_from][msg.sender];
         require(balances[_from] >= _value, "ERC20_INSUFFICIENT_BALANCE");
         require(allowance >= _value, "ERC20_INSUFFICIENT_ALLOWANCE");

--- a/contracts/erc20/contracts/src/WETH9.sol
+++ b/contracts/erc20/contracts/src/WETH9.sol
@@ -58,11 +58,7 @@ contract WETH9 {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(
-        address src,
-        address dst,
-        uint256 wad
-    ) public returns (bool) {
+    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
         require(balanceOf[src] >= wad);
 
         if (src != msg.sender && allowance[src][msg.sender] != uint256(-1)) {

--- a/contracts/erc20/contracts/src/ZRXToken.sol
+++ b/contracts/erc20/contracts/src/ZRXToken.sol
@@ -37,11 +37,7 @@ contract Token {
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return Whether the transfer was successful or not
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) returns (bool success) {}
+    function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {}
 
     /// @notice `msg.sender` approves `_addr` to spend `_value` tokens
     /// @param _spender The address of the account able to transfer the tokens
@@ -71,11 +67,7 @@ contract ERC20Token is Token {
         }
     }
 
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
         if (
             balances[_from] >= _value && allowed[_from][msg.sender] >= _value && balances[_to] + _value >= balances[_to]
         ) {
@@ -109,18 +101,14 @@ contract ERC20Token is Token {
 }
 
 contract UnlimitedAllowanceToken is ERC20Token {
-    uint256 constant MAX_UINT = 2**256 - 1;
+    uint256 constant MAX_UINT = 2 ** 256 - 1;
 
     /// @dev ERC20 transferFrom, modified such that an allowance of MAX_UINT represents an unlimited allowance.
     /// @param _from Address to transfer from.
     /// @param _to Address to transfer to.
     /// @param _value Amount to transfer.
     /// @return Success of transfer.
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) public returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
         uint256 allowance = allowed[_from][msg.sender];
         if (balances[_from] >= _value && allowance >= _value && balances[_to] + _value >= balances[_to]) {
             balances[_to] += _value;
@@ -138,7 +126,7 @@ contract UnlimitedAllowanceToken is ERC20Token {
 
 contract ZRXToken is UnlimitedAllowanceToken {
     uint8 public constant decimals = 18;
-    uint256 public totalSupply = 10**27; // 1 billion tokens, 18 decimal places
+    uint256 public totalSupply = 10 ** 27; // 1 billion tokens, 18 decimal places
     string public constant name = "0x Protocol Token";
     string public constant symbol = "ZRX";
 

--- a/contracts/erc20/contracts/src/interfaces/IERC20Token.sol
+++ b/contracts/erc20/contracts/src/interfaces/IERC20Token.sol
@@ -34,11 +34,7 @@ contract IERC20Token {
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return True if transfer was successful
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) external returns (bool);
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool);
 
     /// @dev `msg.sender` approves `_spender` to spend `_value` tokens
     /// @param _spender The address of the account able to transfer the tokens

--- a/contracts/erc20/contracts/src/v06/IERC20TokenV06.sol
+++ b/contracts/erc20/contracts/src/v06/IERC20TokenV06.sol
@@ -35,11 +35,7 @@ interface IERC20TokenV06 {
     /// @param to The address of the recipient
     /// @param value The amount of token to be transferred
     /// @return True if transfer was successful
-    function transferFrom(
-        address from,
-        address to,
-        uint256 value
-    ) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
 
     /// @dev `msg.sender` approves `spender` to spend `value` tokens
     /// @param spender The address of the account able to transfer the tokens

--- a/contracts/erc20/contracts/src/v06/LibERC20TokenV06.sol
+++ b/contracts/erc20/contracts/src/v06/LibERC20TokenV06.sol
@@ -31,11 +31,7 @@ library LibERC20TokenV06 {
     /// @param token The address of the token contract.
     /// @param spender The address that receives an allowance.
     /// @param allowance The allowance to set.
-    function compatApprove(
-        IERC20TokenV06 token,
-        address spender,
-        uint256 allowance
-    ) internal {
+    function compatApprove(IERC20TokenV06 token, address spender, uint256 allowance) internal {
         bytes memory callData = abi.encodeWithSelector(token.approve.selector, spender, allowance);
         _callWithOptionalBooleanResult(address(token), callData);
     }
@@ -46,11 +42,7 @@ library LibERC20TokenV06 {
     /// @param token The address of the token contract.
     /// @param spender The address that receives an allowance.
     /// @param amount The minimum allowance needed.
-    function approveIfBelow(
-        IERC20TokenV06 token,
-        address spender,
-        uint256 amount
-    ) internal {
+    function approveIfBelow(IERC20TokenV06 token, address spender, uint256 amount) internal {
         if (token.allowance(address(this), spender) < amount) {
             compatApprove(token, spender, uint256(-1));
         }
@@ -61,11 +53,7 @@ library LibERC20TokenV06 {
     /// @param token The address of the token contract.
     /// @param to The address that receives the tokens
     /// @param amount Number of tokens to transfer.
-    function compatTransfer(
-        IERC20TokenV06 token,
-        address to,
-        uint256 amount
-    ) internal {
+    function compatTransfer(IERC20TokenV06 token, address to, uint256 amount) internal {
         bytes memory callData = abi.encodeWithSelector(token.transfer.selector, to, amount);
         _callWithOptionalBooleanResult(address(token), callData);
     }
@@ -76,12 +64,7 @@ library LibERC20TokenV06 {
     /// @param from The owner of the tokens.
     /// @param to The address that receives the tokens
     /// @param amount Number of tokens to transfer.
-    function compatTransferFrom(
-        IERC20TokenV06 token,
-        address from,
-        address to,
-        uint256 amount
-    ) internal {
+    function compatTransferFrom(IERC20TokenV06 token, address from, address to, uint256 amount) internal {
         bytes memory callData = abi.encodeWithSelector(token.transferFrom.selector, from, to, amount);
         _callWithOptionalBooleanResult(address(token), callData);
     }

--- a/contracts/erc20/contracts/test/DummyERC20Token.sol
+++ b/contracts/erc20/contracts/test/DummyERC20Token.sol
@@ -30,12 +30,7 @@ contract DummyERC20Token is Ownable, MintableERC20Token {
     uint256 public decimals;
     uint256 public constant MAX_MINT_AMOUNT = 10000000000000000000000;
 
-    constructor(
-        string memory _name,
-        string memory _symbol,
-        uint256 _decimals,
-        uint256 _totalSupply
-    ) public {
+    constructor(string memory _name, string memory _symbol, uint256 _decimals, uint256 _totalSupply) public {
         name = _name;
         symbol = _symbol;
         decimals = _decimals;

--- a/contracts/erc20/contracts/test/DummyMultipleReturnERC20Token.sol
+++ b/contracts/erc20/contracts/test/DummyMultipleReturnERC20Token.sol
@@ -32,11 +32,7 @@ contract DummyMultipleReturnERC20Token is DummyERC20Token {
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) external returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool) {
         emit Transfer(_from, _to, _value);
 
         // HACK: This contract will not compile if we remove `returns (bool)`, so we manually return 64 bytes

--- a/contracts/erc20/contracts/test/DummyNoReturnERC20Token.sol
+++ b/contracts/erc20/contracts/test/DummyNoReturnERC20Token.sol
@@ -50,11 +50,7 @@ contract DummyNoReturnERC20Token is DummyERC20Token {
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) external returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool) {
         require(balances[_from] >= _value, "ERC20_INSUFFICIENT_BALANCE");
         require(allowed[_from][msg.sender] >= _value, "ERC20_INSUFFICIENT_ALLOWANCE");
         require(balances[_to] + _value >= balances[_to], "UINT256_OVERFLOW");

--- a/contracts/erc20/contracts/test/TestLibERC20TokenTarget.sol
+++ b/contracts/erc20/contracts/test/TestLibERC20TokenTarget.sol
@@ -29,11 +29,7 @@ contract TestLibERC20TokenTarget {
     bytes private _revertData;
     bytes private _returnData;
 
-    function setBehavior(
-        bool shouldRevert,
-        bytes calldata revertData,
-        bytes calldata returnData
-    ) external {
+    function setBehavior(bool shouldRevert, bytes calldata revertData, bytes calldata returnData) external {
         _shouldRevert = shouldRevert;
         _revertData = revertData;
         _returnData = returnData;
@@ -49,11 +45,7 @@ contract TestLibERC20TokenTarget {
         _execute();
     }
 
-    function transferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) external returns (bool) {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
         emit TransferFromCalled(from, to, amount);
         _execute();
     }

--- a/contracts/erc20/contracts/test/UntransferrableDummyERC20Token.sol
+++ b/contracts/erc20/contracts/test/UntransferrableDummyERC20Token.sol
@@ -32,11 +32,7 @@ contract UntransferrableDummyERC20Token is DummyERC20Token {
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _value
-    ) external returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool) {
         require(false, "TRANSFER_DISABLED");
     }
 }

--- a/contracts/treasury/contracts/external/ISablier.sol
+++ b/contracts/treasury/contracts/external/ISablier.sol
@@ -36,7 +36,9 @@ interface ISablier {
 
     function balanceOf(uint256 streamId, address who) external view returns (uint256 balance);
 
-    function getStream(uint256 streamId)
+    function getStream(
+        uint256 streamId
+    )
         external
         view
         returns (

--- a/contracts/treasury/contracts/src/DefaultPoolOperator.sol
+++ b/contracts/treasury/contracts/src/DefaultPoolOperator.sol
@@ -36,7 +36,7 @@ contract DefaultPoolOperator {
         stakingProxy = stakingProxy_;
         weth = weth_;
         // operator share = 100%
-        poolId = stakingProxy_.createStakingPool(10**6, false);
+        poolId = stakingProxy_.createStakingPool(10 ** 6, false);
     }
 
     /// @dev Sends this contract's entire WETH balance to the

--- a/contracts/treasury/contracts/src/IStaking.sol
+++ b/contracts/treasury/contracts/src/IStaking.sol
@@ -81,10 +81,10 @@ interface IStaking {
     /// @param staker Owner of stake.
     /// @param stakeStatus UNDELEGATED or DELEGATED
     /// @return balance Owner's stake balances for given status.
-    function getOwnerStakeByStatus(address staker, StakeStatus stakeStatus)
-        external
-        view
-        returns (StoredBalance memory balance);
+    function getOwnerStakeByStatus(
+        address staker,
+        StakeStatus stakeStatus
+    ) external view returns (StoredBalance memory balance);
 
     /// @dev Returns the total stake delegated to a specific staking pool,
     ///      across all members.
@@ -96,8 +96,8 @@ interface IStaking {
     /// @param staker of stake.
     /// @param poolId Unique Id of pool.
     /// @return balance Stake delegated to pool by staker.
-    function getStakeDelegatedToPoolByOwner(address staker, bytes32 poolId)
-        external
-        view
-        returns (StoredBalance memory balance);
+    function getStakeDelegatedToPoolByOwner(
+        address staker,
+        bytes32 poolId
+    ) external view returns (StoredBalance memory balance);
 }

--- a/contracts/treasury/contracts/src/IZrxTreasury.sol
+++ b/contracts/treasury/contracts/src/IZrxTreasury.sol
@@ -112,11 +112,7 @@ interface IZrxTreasury {
     /// @param operatedPoolIds The pools operated by `msg.sender`. The
     ///        ZRX currently delegated to those pools will be accounted
     ///        for in the voting power.
-    function castVote(
-        uint256 proposalId,
-        bool support,
-        bytes32[] calldata operatedPoolIds
-    ) external;
+    function castVote(uint256 proposalId, bool support, bytes32[] calldata operatedPoolIds) external;
 
     /// @dev Casts a vote for the given proposal, by signature.
     ///      Only callable during the voting period for that proposal.
@@ -159,8 +155,8 @@ interface IZrxTreasury {
     ///        ZRX currently delegated to those pools will be accounted
     ///        for in the voting power.
     /// @return votingPower The current voting power of the given account.
-    function getVotingPower(address account, bytes32[] calldata operatedPoolIds)
-        external
-        view
-        returns (uint256 votingPower);
+    function getVotingPower(
+        address account,
+        bytes32[] calldata operatedPoolIds
+    ) external view returns (uint256 votingPower);
 }

--- a/contracts/treasury/contracts/src/ZrxTreasury.sol
+++ b/contracts/treasury/contracts/src/ZrxTreasury.sol
@@ -144,11 +144,7 @@ contract ZrxTreasury is IZrxTreasury {
     /// @param operatedPoolIds The pools operated by `msg.sender`. The
     ///        ZRX currently delegated to those pools will be accounted
     ///        for in the voting power.
-    function castVote(
-        uint256 proposalId,
-        bool support,
-        bytes32[] memory operatedPoolIds
-    ) public override {
+    function castVote(uint256 proposalId, bool support, bytes32[] memory operatedPoolIds) public override {
         return _castVote(msg.sender, proposalId, support, operatedPoolIds);
     }
 
@@ -219,12 +215,10 @@ contract ZrxTreasury is IZrxTreasury {
     ///        ZRX currently delegated to those pools will be accounted
     ///        for in the voting power.
     /// @return votingPower The current voting power of the given account.
-    function getVotingPower(address account, bytes32[] memory operatedPoolIds)
-        public
-        view
-        override
-        returns (uint256 votingPower)
-    {
+    function getVotingPower(
+        address account,
+        bytes32[] memory operatedPoolIds
+    ) public view override returns (uint256 votingPower) {
         uint256 delegatedBalance = stakingProxy
             .getOwnerStakeByStatus(account, IStaking.StakeStatus.DELEGATED)
             .currentEpochBalance;
@@ -307,12 +301,7 @@ contract ZrxTreasury is IZrxTreasury {
     /// @dev Casts a vote for the given proposal. Only callable
     ///      during the voting period for that proposal. See
     ///      `getVotingPower` for how voting power is computed.
-    function _castVote(
-        address voter,
-        uint256 proposalId,
-        bool support,
-        bytes32[] memory operatedPoolIds
-    ) private {
+    function _castVote(address voter, uint256 proposalId, bool support, bytes32[] memory operatedPoolIds) private {
         if (proposalId >= proposalCount()) {
             revert("_castVote/INVALID_PROPOSAL_ID");
         }

--- a/contracts/utils/contracts/src/D18.sol
+++ b/contracts/utils/contracts/src/D18.sol
@@ -23,7 +23,7 @@ library D18 {
     /// @dev Decimal places for dydx value quantities.
     uint256 private constant PRECISION = 18;
     /// @dev 1.0 in base-18 decimal.
-    int256 private constant DECIMAL_ONE = int256(10**PRECISION);
+    int256 private constant DECIMAL_ONE = int256(10 ** PRECISION);
     /// @dev Minimum signed integer value.
     int256 private constant MIN_INT256_VALUE =
         int256(0x8000000000000000000000000000000000000000000000000000000000000000);

--- a/contracts/utils/contracts/src/LibAddressArray.sol
+++ b/contracts/utils/contracts/src/LibAddressArray.sol
@@ -117,11 +117,10 @@ library LibAddressArray {
     /// @param addressArray Array of addresses.
     /// @param target Address to search for in array.
     /// @return Existence and index of the target in the array.
-    function indexOf(address[] memory addressArray, address target)
-        internal
-        pure
-        returns (bool success, uint256 index)
-    {
+    function indexOf(
+        address[] memory addressArray,
+        address target
+    ) internal pure returns (bool success, uint256 index) {
         assembly {
             // Calculate byte length of array
             let arrayByteLen := mul(mload(addressArray), 32)

--- a/contracts/utils/contracts/src/LibAddressArrayRichErrors.sol
+++ b/contracts/utils/contracts/src/LibAddressArrayRichErrors.sol
@@ -22,11 +22,10 @@ library LibAddressArrayRichErrors {
     // bytes4(keccak256("MismanagedMemoryError(uint256,uint256)"))
     bytes4 internal constant MISMANAGED_MEMORY_ERROR_SELECTOR = 0x5fc83722;
 
-    function MismanagedMemoryError(uint256 freeMemPtr, uint256 addressArrayEndPtr)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function MismanagedMemoryError(
+        uint256 freeMemPtr,
+        uint256 addressArrayEndPtr
+    ) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(MISMANAGED_MEMORY_ERROR_SELECTOR, freeMemPtr, addressArrayEndPtr);
     }
 }

--- a/contracts/utils/contracts/src/LibBytes.sol
+++ b/contracts/utils/contracts/src/LibBytes.sol
@@ -50,11 +50,7 @@ library LibBytes {
     /// @param dest memory address to copy bytes to.
     /// @param source memory address to copy bytes from.
     /// @param length number of bytes to copy.
-    function memCopy(
-        uint256 dest,
-        uint256 source,
-        uint256 length
-    ) internal pure {
+    function memCopy(uint256 dest, uint256 source, uint256 length) internal pure {
         if (length < 32) {
             // Handle a partial word by reading destination and masking
             // off the bits we are interested in.
@@ -161,11 +157,7 @@ library LibBytes {
     /// @param from The starting index for the slice (inclusive).
     /// @param to The final index for the slice (exclusive).
     /// @return result The slice containing bytes at indices [from, to)
-    function slice(
-        bytes memory b,
-        uint256 from,
-        uint256 to
-    ) internal pure returns (bytes memory result) {
+    function slice(bytes memory b, uint256 from, uint256 to) internal pure returns (bytes memory result) {
         // Ensure that the from and to positions are valid positions for a slice within
         // the byte array that is being used.
         if (from > to) {
@@ -199,11 +191,7 @@ library LibBytes {
     /// @param to The final index for the slice (exclusive).
     /// @return result The slice containing bytes at indices [from, to)
     /// @dev When `from == 0`, the original array will match the slice. In other cases its state will be corrupted.
-    function sliceDestructive(
-        bytes memory b,
-        uint256 from,
-        uint256 to
-    ) internal pure returns (bytes memory result) {
+    function sliceDestructive(bytes memory b, uint256 from, uint256 to) internal pure returns (bytes memory result) {
         // Ensure that the from and to positions are valid positions for a slice within
         // the byte array that is being used.
         if (from > to) {
@@ -303,11 +291,7 @@ library LibBytes {
     /// @param b Byte array to insert address into.
     /// @param index Index in byte array of address.
     /// @param input Address to put into byte array.
-    function writeAddress(
-        bytes memory b,
-        uint256 index,
-        address input
-    ) internal pure {
+    function writeAddress(bytes memory b, uint256 index, address input) internal pure {
         if (b.length < index + 20) {
             LibRichErrors.rrevert(
                 LibBytesRichErrors.InvalidByteOperationError(
@@ -376,11 +360,7 @@ library LibBytes {
     /// @param b Byte array to insert <input> into.
     /// @param index Index in byte array of <input>.
     /// @param input bytes32 to put into byte array.
-    function writeBytes32(
-        bytes memory b,
-        uint256 index,
-        bytes32 input
-    ) internal pure {
+    function writeBytes32(bytes memory b, uint256 index, bytes32 input) internal pure {
         if (b.length < index + 32) {
             LibRichErrors.rrevert(
                 LibBytesRichErrors.InvalidByteOperationError(
@@ -413,11 +393,7 @@ library LibBytes {
     /// @param b Byte array to insert <input> into.
     /// @param index Index in byte array of <input>.
     /// @param input uint256 to put into byte array.
-    function writeUint256(
-        bytes memory b,
-        uint256 index,
-        uint256 input
-    ) internal pure {
+    function writeUint256(bytes memory b, uint256 index, uint256 input) internal pure {
         writeBytes32(b, index, bytes32(input));
     }
 

--- a/contracts/utils/contracts/src/LibFractions.sol
+++ b/contracts/utils/contracts/src/LibFractions.sol
@@ -62,12 +62,11 @@ library LibFractions {
     /// @param denominator The denominator.
     /// @return scaledNumerator The rescaled numerator.
     /// @return scaledDenominator The rescaled denominator.
-    function normalize(uint256 numerator, uint256 denominator)
-        internal
-        pure
-        returns (uint256 scaledNumerator, uint256 scaledDenominator)
-    {
-        return normalize(numerator, denominator, 2**127);
+    function normalize(
+        uint256 numerator,
+        uint256 denominator
+    ) internal pure returns (uint256 scaledNumerator, uint256 scaledDenominator) {
+        return normalize(numerator, denominator, 2 ** 127);
     }
 
     /// @dev Safely scales the difference between two fractions.

--- a/contracts/utils/contracts/src/LibSafeMathRichErrors.sol
+++ b/contracts/utils/contracts/src/LibSafeMathRichErrors.sol
@@ -20,11 +20,7 @@ library LibSafeMathRichErrors {
         VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT96
     }
 
-    function Uint256BinOpError(
-        BinOpErrorCodes errorCode,
-        uint256 a,
-        uint256 b
-    ) internal pure returns (bytes memory) {
+    function Uint256BinOpError(BinOpErrorCodes errorCode, uint256 a, uint256 b) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(UINT256_BINOP_ERROR_SELECTOR, errorCode, a, b);
     }
 

--- a/contracts/utils/contracts/src/v06/LibBytesV06.sol
+++ b/contracts/utils/contracts/src/v06/LibBytesV06.sol
@@ -51,11 +51,7 @@ library LibBytesV06 {
     /// @param dest memory address to copy bytes to.
     /// @param source memory address to copy bytes from.
     /// @param length number of bytes to copy.
-    function memCopy(
-        uint256 dest,
-        uint256 source,
-        uint256 length
-    ) internal pure {
+    function memCopy(uint256 dest, uint256 source, uint256 length) internal pure {
         if (length < 32) {
             // Handle a partial word by reading destination and masking
             // off the bits we are interested in.
@@ -162,11 +158,7 @@ library LibBytesV06 {
     /// @param from The starting index for the slice (inclusive).
     /// @param to The final index for the slice (exclusive).
     /// @return result The slice containing bytes at indices [from, to)
-    function slice(
-        bytes memory b,
-        uint256 from,
-        uint256 to
-    ) internal pure returns (bytes memory result) {
+    function slice(bytes memory b, uint256 from, uint256 to) internal pure returns (bytes memory result) {
         // Ensure that the from and to positions are valid positions for a slice within
         // the byte array that is being used.
         if (from > to) {
@@ -201,11 +193,7 @@ library LibBytesV06 {
     /// @param from The starting index for the slice (inclusive).
     /// @param to The final index for the slice (exclusive).
     /// @return result The slice containing bytes at indices [from, to)
-    function sliceDestructive(
-        bytes memory b,
-        uint256 from,
-        uint256 to
-    ) internal pure returns (bytes memory result) {
+    function sliceDestructive(bytes memory b, uint256 from, uint256 to) internal pure returns (bytes memory result) {
         // Ensure that the from and to positions are valid positions for a slice within
         // the byte array that is being used.
         if (from > to) {
@@ -305,11 +293,7 @@ library LibBytesV06 {
     /// @param b Byte array to insert address into.
     /// @param index Index in byte array of address.
     /// @param input Address to put into byte array.
-    function writeAddress(
-        bytes memory b,
-        uint256 index,
-        address input
-    ) internal pure {
+    function writeAddress(bytes memory b, uint256 index, address input) internal pure {
         if (b.length < index + 20) {
             LibRichErrorsV06.rrevert(
                 LibBytesRichErrorsV06.InvalidByteOperationError(
@@ -378,11 +362,7 @@ library LibBytesV06 {
     /// @param b Byte array to insert <input> into.
     /// @param index Index in byte array of <input>.
     /// @param input bytes32 to put into byte array.
-    function writeBytes32(
-        bytes memory b,
-        uint256 index,
-        bytes32 input
-    ) internal pure {
+    function writeBytes32(bytes memory b, uint256 index, bytes32 input) internal pure {
         if (b.length < index + 32) {
             LibRichErrorsV06.rrevert(
                 LibBytesRichErrorsV06.InvalidByteOperationError(
@@ -415,11 +395,7 @@ library LibBytesV06 {
     /// @param b Byte array to insert <input> into.
     /// @param index Index in byte array of <input>.
     /// @param input uint256 to put into byte array.
-    function writeUint256(
-        bytes memory b,
-        uint256 index,
-        uint256 input
-    ) internal pure {
+    function writeUint256(bytes memory b, uint256 index, uint256 input) internal pure {
         writeBytes32(b, index, bytes32(input));
     }
 

--- a/contracts/utils/contracts/src/v06/errors/LibSafeMathRichErrorsV06.sol
+++ b/contracts/utils/contracts/src/v06/errors/LibSafeMathRichErrorsV06.sol
@@ -40,11 +40,7 @@ library LibSafeMathRichErrorsV06 {
         VALUE_TOO_LARGE_TO_DOWNCAST_TO_UINT128
     }
 
-    function Uint256BinOpError(
-        BinOpErrorCodes errorCode,
-        uint256 a,
-        uint256 b
-    ) internal pure returns (bytes memory) {
+    function Uint256BinOpError(BinOpErrorCodes errorCode, uint256 a, uint256 b) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(UINT256_BINOP_ERROR_SELECTOR, errorCode, a, b);
     }
 

--- a/contracts/utils/contracts/test/TestLibAddressArray.sol
+++ b/contracts/utils/contracts/test/TestLibAddressArray.sol
@@ -30,11 +30,10 @@ contract TestLibAddressArray {
     /// @param addressArray Array of addresses.
     /// @param addressToAppend  Address to append.
     /// @return Array of addresses: [... addressArray, addressToAppend]
-    function publicAppend(address[] memory addressArray, address addressToAppend)
-        public
-        pure
-        returns (address[] memory)
-    {
+    function publicAppend(
+        address[] memory addressArray,
+        address addressToAppend
+    ) public pure returns (address[] memory) {
         return addressArray.append(addressToAppend);
     }
 
@@ -52,15 +51,7 @@ contract TestLibAddressArray {
         address[] memory addressArray,
         int256 freeMemOffset,
         address addressToAppend
-    )
-        public
-        pure
-        returns (
-            address[] memory result,
-            uint256 oldArrayMemStart,
-            uint256 newArrayMemStart
-        )
-    {
+    ) public pure returns (address[] memory result, uint256 oldArrayMemStart, uint256 newArrayMemStart) {
         assembly {
             // Remember the original memory address of the array.
             oldArrayMemStart := addressArray
@@ -89,11 +80,10 @@ contract TestLibAddressArray {
     /// @param addressArray Array of addresses.
     /// @param target Address to search for in array.
     /// @return Existence and index of the target in the array.
-    function publicIndexOf(address[] memory addressArray, address target)
-        public
-        pure
-        returns (bool success, uint256 index)
-    {
+    function publicIndexOf(
+        address[] memory addressArray,
+        address target
+    ) public pure returns (bool success, uint256 index) {
         (success, index) = addressArray.indexOf(target);
     }
 }

--- a/contracts/utils/contracts/test/TestLibBytes.sol
+++ b/contracts/utils/contracts/test/TestLibBytes.sol
@@ -60,11 +60,7 @@ contract TestLibBytes {
     /// @param b Byte array to insert address into.
     /// @param index Index in byte array of address.
     /// @param input Address to put into byte array.
-    function publicWriteAddress(
-        bytes memory b,
-        uint256 index,
-        address input
-    ) public pure returns (bytes memory) {
+    function publicWriteAddress(bytes memory b, uint256 index, address input) public pure returns (bytes memory) {
         b.writeAddress(index, input);
         return b;
     }
@@ -82,11 +78,7 @@ contract TestLibBytes {
     /// @param b Byte array to insert <input> into.
     /// @param index Index in byte array of <input>.
     /// @param input bytes32 to put into byte array.
-    function publicWriteBytes32(
-        bytes memory b,
-        uint256 index,
-        bytes32 input
-    ) public pure returns (bytes memory) {
+    function publicWriteBytes32(bytes memory b, uint256 index, bytes32 input) public pure returns (bytes memory) {
         b.writeBytes32(index, input);
         return b;
     }
@@ -104,11 +96,7 @@ contract TestLibBytes {
     /// @param b Byte array to insert <input> into.
     /// @param index Index in byte array of <input>.
     /// @param input uint256 to put into byte array.
-    function publicWriteUint256(
-        bytes memory b,
-        uint256 index,
-        uint256 input
-    ) public pure returns (bytes memory) {
+    function publicWriteUint256(bytes memory b, uint256 index, uint256 input) public pure returns (bytes memory) {
         b.writeUint256(index, input);
         return b;
     }

--- a/contracts/zero-ex/contracts/src/errors/LibMetaTransactionsRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibMetaTransactionsRichErrors.sol
@@ -20,11 +20,10 @@
 pragma solidity ^0.6.5;
 
 library LibMetaTransactionsRichErrors {
-    function InvalidMetaTransactionsArrayLengthsError(uint256 mtxCount, uint256 signatureCount)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function InvalidMetaTransactionsArrayLengthsError(
+        uint256 mtxCount,
+        uint256 signatureCount
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("InvalidMetaTransactionsArrayLengthsError(uint256,uint256)")),
@@ -33,11 +32,10 @@ library LibMetaTransactionsRichErrors {
             );
     }
 
-    function MetaTransactionUnsupportedFunctionError(bytes32 mtxHash, bytes4 selector)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function MetaTransactionUnsupportedFunctionError(
+        bytes32 mtxHash,
+        bytes4 selector
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("MetaTransactionUnsupportedFunctionError(bytes32,bytes4)")),
@@ -118,11 +116,10 @@ library LibMetaTransactionsRichErrors {
             );
     }
 
-    function MetaTransactionAlreadyExecutedError(bytes32 mtxHash, uint256 executedBlockNumber)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function MetaTransactionAlreadyExecutedError(
+        bytes32 mtxHash,
+        uint256 executedBlockNumber
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("MetaTransactionAlreadyExecutedError(bytes32,uint256)")),

--- a/contracts/zero-ex/contracts/src/errors/LibNFTOrdersRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibNFTOrdersRichErrors.sol
@@ -54,11 +54,10 @@ library LibNFTOrdersRichErrors {
             );
     }
 
-    function SellOrderFeesExceedSpreadError(uint256 sellOrderFees, uint256 spread)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function SellOrderFeesExceedSpreadError(
+        uint256 sellOrderFees,
+        uint256 spread
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("SellOrderFeesExceedSpreadError(uint256,uint256)")),
@@ -112,11 +111,10 @@ library LibNFTOrdersRichErrors {
             );
     }
 
-    function ExceedsRemainingOrderAmount(uint128 remainingOrderAmount, uint128 fillAmount)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function ExceedsRemainingOrderAmount(
+        uint128 remainingOrderAmount,
+        uint128 fillAmount
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("ExceedsRemainingOrderAmount(uint128,uint128)")),

--- a/contracts/zero-ex/contracts/src/errors/LibSignatureRichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibSignatureRichErrors.sol
@@ -45,11 +45,10 @@ library LibSignatureRichErrors {
             );
     }
 
-    function SignatureValidationError(SignatureValidationErrorCodes code, bytes32 hash)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function SignatureValidationError(
+        SignatureValidationErrorCodes code,
+        bytes32 hash
+    ) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(bytes4(keccak256("SignatureValidationError(uint8,bytes32)")), code, hash);
     }
 }

--- a/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
@@ -43,11 +43,10 @@ library LibTransformERC20RichErrors {
             );
     }
 
-    function NegativeTransformERC20OutputError(address outputToken, uint256 outputTokenLostAmount)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function NegativeTransformERC20OutputError(
+        address outputToken,
+        uint256 outputTokenLostAmount
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("NegativeTransformERC20OutputError(address,uint256)")),
@@ -77,11 +76,10 @@ library LibTransformERC20RichErrors {
             abi.encodeWithSelector(bytes4(keccak256("OnlyCallableByDeployerError(address,address)")), caller, deployer);
     }
 
-    function InvalidExecutionContextError(address actualContext, address expectedContext)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function InvalidExecutionContextError(
+        address actualContext,
+        address expectedContext
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("InvalidExecutionContextError(address,address)")),
@@ -95,11 +93,10 @@ library LibTransformERC20RichErrors {
         INVALID_ARRAY_LENGTH
     }
 
-    function InvalidTransformDataError(InvalidTransformDataErrorCode errorCode, bytes memory transformData)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function InvalidTransformDataError(
+        InvalidTransformDataErrorCode errorCode,
+        bytes memory transformData
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("InvalidTransformDataError(uint8,bytes)")),
@@ -138,11 +135,10 @@ library LibTransformERC20RichErrors {
             );
     }
 
-    function InsufficientTakerTokenError(uint256 tokenBalance, uint256 tokensNeeded)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function InsufficientTakerTokenError(
+        uint256 tokenBalance,
+        uint256 tokensNeeded
+    ) internal pure returns (bytes memory) {
         return
             abi.encodeWithSelector(
                 bytes4(keccak256("InsufficientTakerTokenError(uint256,uint256)")),

--- a/contracts/zero-ex/contracts/src/external/FeeCollector.sol
+++ b/contracts/zero-ex/contracts/src/external/FeeCollector.sol
@@ -38,11 +38,7 @@ contract FeeCollector is AuthorizableV06 {
     /// @param weth The WETH contract.
     /// @param staking The staking contract.
     /// @param poolId The pool ID this contract is collecting fees for.
-    function initialize(
-        IEtherTokenV06 weth,
-        IStaking staking,
-        bytes32 poolId
-    ) external onlyAuthorized {
+    function initialize(IEtherTokenV06 weth, IStaking staking, bytes32 poolId) external onlyAuthorized {
         weth.approve(address(staking), type(uint256).max);
         staking.joinStakingPoolAsMaker(poolId);
     }

--- a/contracts/zero-ex/contracts/src/external/FlashWallet.sol
+++ b/contracts/zero-ex/contracts/src/external/FlashWallet.sol
@@ -69,13 +69,10 @@ contract FlashWallet is IFlashWallet {
     /// @param target The call target.
     /// @param callData The call data.
     /// @return resultData The data returned by the call.
-    function executeDelegateCall(address payable target, bytes calldata callData)
-        external
-        payable
-        override
-        onlyOwner
-        returns (bytes memory resultData)
-    {
+    function executeDelegateCall(
+        address payable target,
+        bytes calldata callData
+    ) external payable override onlyOwner returns (bytes memory resultData) {
         bool success;
         (success, resultData) = target.delegatecall(callData);
         if (!success) {

--- a/contracts/zero-ex/contracts/src/external/IFlashWallet.sol
+++ b/contracts/zero-ex/contracts/src/external/IFlashWallet.sol
@@ -40,10 +40,10 @@ interface IFlashWallet {
     /// @param target The call target.
     /// @param callData The call data.
     /// @return resultData The data returned by the call.
-    function executeDelegateCall(address payable target, bytes calldata callData)
-        external
-        payable
-        returns (bytes memory resultData);
+    function executeDelegateCall(
+        address payable target,
+        bytes calldata callData
+    ) external payable returns (bytes memory resultData);
 
     /// @dev Allows the puppet to receive ETH.
     receive() external payable;

--- a/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/MetaTransactionsFeature.sol
@@ -131,7 +131,10 @@ contract MetaTransactionsFeature is
     /// @param mtx The meta-transaction.
     /// @param signature The signature by `mtx.signer`.
     /// @return returnResult The ABI-encoded result of the underlying call.
-    function executeMetaTransaction(MetaTransactionData memory mtx, LibSignature.Signature memory signature)
+    function executeMetaTransaction(
+        MetaTransactionData memory mtx,
+        LibSignature.Signature memory signature
+    )
         public
         payable
         override
@@ -153,7 +156,10 @@ contract MetaTransactionsFeature is
     /// @param mtxs The meta-transactions.
     /// @param signatures The signature by each respective `mtx.signer`.
     /// @return returnResults The ABI-encoded results of the underlying calls.
-    function batchExecuteMetaTransactions(MetaTransactionData[] memory mtxs, LibSignature.Signature[] memory signatures)
+    function batchExecuteMetaTransactions(
+        MetaTransactionData[] memory mtxs,
+        LibSignature.Signature[] memory signatures
+    )
         public
         payable
         override
@@ -182,12 +188,9 @@ contract MetaTransactionsFeature is
     /// @dev Get the block at which a meta-transaction has been executed.
     /// @param mtx The meta-transaction.
     /// @return blockNumber The block height when the meta-transactioin was executed.
-    function getMetaTransactionExecutedBlock(MetaTransactionData memory mtx)
-        public
-        view
-        override
-        returns (uint256 blockNumber)
-    {
+    function getMetaTransactionExecutedBlock(
+        MetaTransactionData memory mtx
+    ) public view override returns (uint256 blockNumber) {
         return getMetaTransactionHashExecutedBlock(getMetaTransactionHash(mtx));
     }
 
@@ -459,11 +462,7 @@ contract MetaTransactionsFeature is
 
     /// @dev Make an arbitrary internal, meta-transaction call.
     ///      Warning: Do not let unadulterated `callData` into this function.
-    function _callSelf(
-        bytes32 hash,
-        bytes memory callData,
-        uint256 value
-    ) private returns (bytes memory returnResult) {
+    function _callSelf(bytes32 hash, bytes memory callData, uint256 value) private returns (bytes memory returnResult) {
         bool success;
         (success, returnResult) = address(this).call{value: value}(callData);
         if (!success) {

--- a/contracts/zero-ex/contracts/src/features/OtcOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/OtcOrdersFeature.sol
@@ -147,12 +147,10 @@ contract OtcOrdersFeature is IFeature, IOtcOrdersFeature, FixinCommon, FixinEIP7
     /// @param makerSignature The order signature from the maker.
     /// @return takerTokenFilledAmount How much taker token was filled.
     /// @return makerTokenFilledAmount How much maker token was filled.
-    function fillOtcOrderWithEth(LibNativeOrder.OtcOrder memory order, LibSignature.Signature memory makerSignature)
-        public
-        payable
-        override
-        returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount)
-    {
+    function fillOtcOrderWithEth(
+        LibNativeOrder.OtcOrder memory order,
+        LibSignature.Signature memory makerSignature
+    ) public payable override returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount) {
         if (order.takerToken == WETH) {
             // Wrap ETH
             WETH.deposit{value: msg.value}();
@@ -425,12 +423,9 @@ contract OtcOrdersFeature is IFeature, IOtcOrdersFeature, FixinCommon, FixinEIP7
     /// @dev Get the order info for an OTC order.
     /// @param order The OTC order.
     /// @return orderInfo Info about the order.
-    function getOtcOrderInfo(LibNativeOrder.OtcOrder memory order)
-        public
-        view
-        override
-        returns (LibNativeOrder.OtcOrderInfo memory orderInfo)
-    {
+    function getOtcOrderInfo(
+        LibNativeOrder.OtcOrder memory order
+    ) public view override returns (LibNativeOrder.OtcOrderInfo memory orderInfo) {
         // compute order hash.
         orderInfo.orderHash = getOtcOrderHash(order);
 
@@ -470,12 +465,10 @@ contract OtcOrdersFeature is IFeature, IOtcOrdersFeature, FixinCommon, FixinEIP7
     /// @param txOrigin The address.
     /// @param nonceBucket The nonce bucket index.
     /// @return lastNonce The last nonce value used.
-    function lastOtcTxOriginNonce(address txOrigin, uint64 nonceBucket)
-        public
-        view
-        override
-        returns (uint128 lastNonce)
-    {
+    function lastOtcTxOriginNonce(
+        address txOrigin,
+        uint64 nonceBucket
+    ) public view override returns (uint128 lastNonce) {
         LibOtcOrdersStorage.Storage storage stor = LibOtcOrdersStorage.getStorage();
         return stor.txOriginNonces[txOrigin][nonceBucket];
     }

--- a/contracts/zero-ex/contracts/src/features/OwnableFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/OwnableFeature.sol
@@ -77,11 +77,7 @@ contract OwnableFeature is IFeature, IOwnableFeature, FixinCommon {
     /// @param target The migrator contract address.
     /// @param data The call data.
     /// @param newOwner The address of the new owner.
-    function migrate(
-        address target,
-        bytes calldata data,
-        address newOwner
-    ) external override onlyOwner {
+    function migrate(address target, bytes calldata data, address newOwner) external override onlyOwner {
         if (newOwner == address(0)) {
             LibOwnableRichErrors.TransferOwnerToZeroError().rrevert();
         }

--- a/contracts/zero-ex/contracts/src/features/PancakeSwapFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/PancakeSwapFeature.sol
@@ -85,7 +85,7 @@ contract PancakeSwapFeature is IFeature, IPancakeSwapFeature, FixinCommon {
     // BNB pseudo-token address.
     uint256 private constant ETH_TOKEN_ADDRESS_32 = 0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee;
     // Maximum token quantity that can be swapped against the PancakeSwapPair contract.
-    uint256 private constant MAX_SWAP_AMOUNT = 2**112;
+    uint256 private constant MAX_SWAP_AMOUNT = 2 ** 112;
 
     // bytes4(keccak256("executeCall(address,bytes)"))
     uint256 private constant ALLOWANCE_TARGET_EXECUTE_CALL_SELECTOR_32 =

--- a/contracts/zero-ex/contracts/src/features/TransformERC20Feature.sol
+++ b/contracts/zero-ex/contracts/src/features/TransformERC20Feature.sol
@@ -153,14 +153,9 @@ contract TransformERC20Feature is IFeature, ITransformERC20Feature, FixinCommon,
     /// @dev Internal version of `transformERC20()`. Only callable from within.
     /// @param args A `TransformERC20Args` struct.
     /// @return outputTokenAmount The amount of `outputToken` received by the taker.
-    function _transformERC20(TransformERC20Args memory args)
-        public
-        payable
-        virtual
-        override
-        onlySelf
-        returns (uint256 outputTokenAmount)
-    {
+    function _transformERC20(
+        TransformERC20Args memory args
+    ) public payable virtual override onlySelf returns (uint256 outputTokenAmount) {
         return _transformERC20Private(args);
     }
 

--- a/contracts/zero-ex/contracts/src/features/UniswapFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/UniswapFeature.sol
@@ -51,7 +51,7 @@ contract UniswapFeature is IFeature, IUniswapFeature, FixinCommon {
     // ETH pseudo-token address.
     uint256 private constant ETH_TOKEN_ADDRESS_32 = 0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee;
     // Maximum token quantity that can be swapped against the UniswapV2Pair contract.
-    uint256 private constant MAX_SWAP_AMOUNT = 2**112;
+    uint256 private constant MAX_SWAP_AMOUNT = 2 ** 112;
 
     // bytes4(keccak256("executeCall(address,bytes)"))
     uint256 private constant ALLOWANCE_TARGET_EXECUTE_CALL_SELECTOR_32 =

--- a/contracts/zero-ex/contracts/src/features/UniswapV3Feature.sol
+++ b/contracts/zero-ex/contracts/src/features/UniswapV3Feature.sol
@@ -62,11 +62,7 @@ contract UniswapV3Feature is IFeature, IUniswapV3Feature, FixinCommon, FixinToke
     /// @param weth The WETH contract.
     /// @param uniFactory The UniswapV3 factory contract.
     /// @param poolInitCodeHash The UniswapV3 pool init code hash.
-    constructor(
-        IEtherTokenV06 weth,
-        address uniFactory,
-        bytes32 poolInitCodeHash
-    ) public {
+    constructor(IEtherTokenV06 weth, address uniFactory, bytes32 poolInitCodeHash) public {
         WETH = weth;
         UNI_FF_FACTORY_ADDRESS = bytes32((uint256(0xff) << 248) | (uint256(uniFactory) << 88));
         UNI_POOL_INIT_CODE_HASH = poolInitCodeHash;
@@ -171,11 +167,7 @@ contract UniswapV3Feature is IFeature, IUniswapV3Feature, FixinCommon, FixinToke
     /// @param amount1Delta Token1 amount owed.
     /// @param data Arbitrary data forwarded from swap() caller. An ABI-encoded
     ///        struct of: inputToken, outputToken, fee, payer
-    function uniswapV3SwapCallback(
-        int256 amount0Delta,
-        int256 amount1Delta,
-        bytes calldata data
-    ) external override {
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external override {
         IERC20TokenV06 token0;
         IERC20TokenV06 token1;
         address payer;
@@ -261,12 +253,7 @@ contract UniswapV3Feature is IFeature, IUniswapV3Feature, FixinCommon, FixinToke
 
     // Pay tokens from `payer` to `to`, using `transferFrom()` if
     // `payer` != this contract.
-    function _pay(
-        IERC20TokenV06 token,
-        address payer,
-        address to,
-        uint256 amount
-    ) private {
+    function _pay(IERC20TokenV06 token, address payer, address to, uint256 amount) private {
         if (payer != address(this)) {
             _transferERC20TokensFrom(token, payer, to, amount);
         } else {
@@ -330,15 +317,9 @@ contract UniswapV3Feature is IFeature, IUniswapV3Feature, FixinCommon, FixinToke
     }
 
     // Return the first input token, output token, and fee of an encoded uniswap path.
-    function _decodeFirstPoolInfoFromPath(bytes memory encodedPath)
-        private
-        pure
-        returns (
-            IERC20TokenV06 inputToken,
-            uint24 fee,
-            IERC20TokenV06 outputToken
-        )
-    {
+    function _decodeFirstPoolInfoFromPath(
+        bytes memory encodedPath
+    ) private pure returns (IERC20TokenV06 inputToken, uint24 fee, IERC20TokenV06 outputToken) {
         require(encodedPath.length >= SINGLE_HOP_PATH_SIZE, "UniswapV3Feature/BAD_PATH_ENCODING");
         assembly {
             let p := add(encodedPath, 32)

--- a/contracts/zero-ex/contracts/src/features/interfaces/IERC1155OrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IERC1155OrdersFeature.sol
@@ -199,17 +199,17 @@ interface IERC1155OrdersFeature {
     ///      an ERC1155 asset.
     /// @param order The ERC1155 order.
     /// @param erc1155TokenId The ID of the ERC1155 asset.
-    function validateERC1155OrderProperties(LibNFTOrder.ERC1155Order calldata order, uint256 erc1155TokenId)
-        external
-        view;
+    function validateERC1155OrderProperties(
+        LibNFTOrder.ERC1155Order calldata order,
+        uint256 erc1155TokenId
+    ) external view;
 
     /// @dev Get the order info for an ERC1155 order.
     /// @param order The ERC1155 order.
     /// @return orderInfo Infor about the order.
-    function getERC1155OrderInfo(LibNFTOrder.ERC1155Order calldata order)
-        external
-        view
-        returns (LibNFTOrder.OrderInfo memory orderInfo);
+    function getERC1155OrderInfo(
+        LibNFTOrder.ERC1155Order calldata order
+    ) external view returns (LibNFTOrder.OrderInfo memory orderInfo);
 
     /// @dev Get the EIP-712 hash of an ERC1155 order.
     /// @param order The ERC1155 order.

--- a/contracts/zero-ex/contracts/src/features/interfaces/IERC721OrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IERC721OrdersFeature.sol
@@ -230,10 +230,9 @@ interface IERC721OrdersFeature {
     /// @dev Get the current status of an ERC721 order.
     /// @param order The ERC721 order.
     /// @return status The status of the order.
-    function getERC721OrderStatus(LibNFTOrder.ERC721Order calldata order)
-        external
-        view
-        returns (LibNFTOrder.OrderStatus status);
+    function getERC721OrderStatus(
+        LibNFTOrder.ERC721Order calldata order
+    ) external view returns (LibNFTOrder.OrderStatus status);
 
     /// @dev Get the EIP-712 hash of an ERC721 order.
     /// @param order The ERC721 order.

--- a/contracts/zero-ex/contracts/src/features/interfaces/IFundRecoveryFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IFundRecoveryFeature.sol
@@ -24,9 +24,5 @@ interface IFundRecoveryFeature {
     /// @param erc20 ERC20 Token Address.
     /// @param amountOut Amount of tokens to withdraw.
     /// @param recipientWallet Recipient wallet address.
-    function transferTrappedTokensTo(
-        IERC20TokenV06 erc20,
-        uint256 amountOut,
-        address payable recipientWallet
-    ) external;
+    function transferTrappedTokensTo(IERC20TokenV06 erc20, uint256 amountOut, address payable recipientWallet) external;
 }

--- a/contracts/zero-ex/contracts/src/features/interfaces/IMetaTransactionsFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IMetaTransactionsFeature.sol
@@ -61,10 +61,10 @@ interface IMetaTransactionsFeature {
     /// @param mtx The meta-transaction.
     /// @param signature The signature by `mtx.signer`.
     /// @return returnResult The ABI-encoded result of the underlying call.
-    function executeMetaTransaction(MetaTransactionData calldata mtx, LibSignature.Signature calldata signature)
-        external
-        payable
-        returns (bytes memory returnResult);
+    function executeMetaTransaction(
+        MetaTransactionData calldata mtx,
+        LibSignature.Signature calldata signature
+    ) external payable returns (bytes memory returnResult);
 
     /// @dev Execute multiple meta-transactions.
     /// @param mtxs The meta-transactions.
@@ -78,10 +78,9 @@ interface IMetaTransactionsFeature {
     /// @dev Get the block at which a meta-transaction has been executed.
     /// @param mtx The meta-transaction.
     /// @return blockNumber The block height when the meta-transactioin was executed.
-    function getMetaTransactionExecutedBlock(MetaTransactionData calldata mtx)
-        external
-        view
-        returns (uint256 blockNumber);
+    function getMetaTransactionExecutedBlock(
+        MetaTransactionData calldata mtx
+    ) external view returns (uint256 blockNumber);
 
     /// @dev Get the block at which a meta-transaction hash has been executed.
     /// @param mtxHash The meta-transaction hash.

--- a/contracts/zero-ex/contracts/src/features/interfaces/INativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/INativeOrdersFeature.sol
@@ -155,11 +155,7 @@ interface INativeOrdersFeature is INativeOrdersEvents {
     /// @param makerToken The maker token.
     /// @param takerToken The taker token.
     /// @param minValidSalt The new minimum valid salt.
-    function cancelPairLimitOrders(
-        IERC20TokenV06 makerToken,
-        IERC20TokenV06 takerToken,
-        uint256 minValidSalt
-    ) external;
+    function cancelPairLimitOrders(IERC20TokenV06 makerToken, IERC20TokenV06 takerToken, uint256 minValidSalt) external;
 
     /// @dev Cancel all limit orders for a given maker and pair with a salt less
     ///      than the value provided. The caller must be a signer registered to the maker.
@@ -211,11 +207,7 @@ interface INativeOrdersFeature is INativeOrdersEvents {
     /// @param makerToken The maker token.
     /// @param takerToken The taker token.
     /// @param minValidSalt The new minimum valid salt.
-    function cancelPairRfqOrders(
-        IERC20TokenV06 makerToken,
-        IERC20TokenV06 takerToken,
-        uint256 minValidSalt
-    ) external;
+    function cancelPairRfqOrders(IERC20TokenV06 makerToken, IERC20TokenV06 takerToken, uint256 minValidSalt) external;
 
     /// @dev Cancel all RFQ orders for a given maker and pair with a salt less
     ///      than the value provided. The caller must be a signer registered to the maker.
@@ -263,18 +255,16 @@ interface INativeOrdersFeature is INativeOrdersEvents {
     /// @dev Get the order info for a limit order.
     /// @param order The limit order.
     /// @return orderInfo Info about the order.
-    function getLimitOrderInfo(LibNativeOrder.LimitOrder calldata order)
-        external
-        view
-        returns (LibNativeOrder.OrderInfo memory orderInfo);
+    function getLimitOrderInfo(
+        LibNativeOrder.LimitOrder calldata order
+    ) external view returns (LibNativeOrder.OrderInfo memory orderInfo);
 
     /// @dev Get the order info for an RFQ order.
     /// @param order The RFQ order.
     /// @return orderInfo Info about the order.
-    function getRfqOrderInfo(LibNativeOrder.RfqOrder calldata order)
-        external
-        view
-        returns (LibNativeOrder.OrderInfo memory orderInfo);
+    function getRfqOrderInfo(
+        LibNativeOrder.RfqOrder calldata order
+    ) external view returns (LibNativeOrder.OrderInfo memory orderInfo);
 
     /// @dev Get the canonical hash of a limit order.
     /// @param order The limit order.
@@ -319,7 +309,10 @@ interface INativeOrdersFeature is INativeOrdersEvents {
     /// @return actualFillableTakerTokenAmount How much of the order is fillable
     ///         based on maker funds, in taker tokens.
     /// @return isSignatureValid Whether the signature is valid.
-    function getRfqOrderRelevantState(LibNativeOrder.RfqOrder calldata order, LibSignature.Signature calldata signature)
+    function getRfqOrderRelevantState(
+        LibNativeOrder.RfqOrder calldata order,
+        LibSignature.Signature calldata signature
+    )
         external
         view
         returns (

--- a/contracts/zero-ex/contracts/src/features/interfaces/IOtcOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IOtcOrdersFeature.sol
@@ -75,10 +75,10 @@ interface IOtcOrdersFeature {
     /// @param makerSignature The order signature from the maker.
     /// @return takerTokenFilledAmount How much taker token was filled.
     /// @return makerTokenFilledAmount How much maker token was filled.
-    function fillOtcOrderWithEth(LibNativeOrder.OtcOrder calldata order, LibSignature.Signature calldata makerSignature)
-        external
-        payable
-        returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount);
+    function fillOtcOrderWithEth(
+        LibNativeOrder.OtcOrder calldata order,
+        LibSignature.Signature calldata makerSignature
+    ) external payable returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount);
 
     /// @dev Fully fill an OTC order. "Meta-transaction" variant,
     ///      requires order to be signed by both maker and taker.
@@ -144,10 +144,9 @@ interface IOtcOrdersFeature {
     /// @dev Get the order info for an OTC order.
     /// @param order The OTC order.
     /// @return orderInfo Info about the order.
-    function getOtcOrderInfo(LibNativeOrder.OtcOrder calldata order)
-        external
-        view
-        returns (LibNativeOrder.OtcOrderInfo memory orderInfo);
+    function getOtcOrderInfo(
+        LibNativeOrder.OtcOrder calldata order
+    ) external view returns (LibNativeOrder.OtcOrderInfo memory orderInfo);
 
     /// @dev Get the canonical hash of an OTC order.
     /// @param order The OTC order.

--- a/contracts/zero-ex/contracts/src/features/interfaces/IOwnableFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IOwnableFeature.sol
@@ -38,9 +38,5 @@ interface IOwnableFeature is IOwnableV06 {
     /// @param target The migrator contract address.
     /// @param newOwner The address of the new owner.
     /// @param data The call data.
-    function migrate(
-        address target,
-        bytes calldata data,
-        address newOwner
-    ) external;
+    function migrate(address target, bytes calldata data, address newOwner) external;
 }

--- a/contracts/zero-ex/contracts/src/features/interfaces/ITokenSpenderFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/ITokenSpenderFeature.sol
@@ -30,12 +30,7 @@ interface ITokenSpenderFeature {
     /// @param owner The owner of the tokens.
     /// @param to The recipient of the tokens.
     /// @param amount The amount of `token` to transfer.
-    function _spendERC20Tokens(
-        IERC20TokenV06 token,
-        address owner,
-        address to,
-        uint256 amount
-    ) external;
+    function _spendERC20Tokens(IERC20TokenV06 token, address owner, address to, uint256 amount) external;
 
     /// @dev Gets the maximum amount of an ERC20 token `token` that can be
     ///      pulled from `owner`.

--- a/contracts/zero-ex/contracts/src/features/interfaces/IUniswapV3Feature.sol
+++ b/contracts/zero-ex/contracts/src/features/interfaces/IUniswapV3Feature.sol
@@ -82,9 +82,5 @@ interface IUniswapV3Feature {
     /// @param amount1Delta Token1 amount owed.
     /// @param data Arbitrary data forwarded from swap() caller. An ABI-encoded
     ///        struct of: inputToken, outputToken, fee, payer
-    function uniswapV3SwapCallback(
-        int256 amount0Delta,
-        int256 amount1Delta,
-        bytes calldata data
-    ) external;
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external;
 }

--- a/contracts/zero-ex/contracts/src/features/libs/LibNFTOrder.sol
+++ b/contracts/zero-ex/contracts/src/features/libs/LibNFTOrder.sol
@@ -271,10 +271,7 @@ library LibNFTOrder {
             mstore(typeHashPos, _ERC_721_ORDER_TYPEHASH)
             mstore(feesHashPos, feesHash)
             mstore(propertiesHashPos, propertiesHash)
-            structHash := keccak256(
-                typeHashPos,
-                384 /* 32 * 12 */
-            )
+            structHash := keccak256(typeHashPos, 384 /* 32 * 12 */)
 
             mstore(typeHashPos, typeHashMemBefore)
             mstore(feesHashPos, feeHashMemBefore)
@@ -322,10 +319,7 @@ library LibNFTOrder {
             mstore(typeHashPos, _ERC_1155_ORDER_TYPEHASH)
             mstore(feesHashPos, feesHash)
             mstore(propertiesHashPos, propertiesHash)
-            structHash := keccak256(
-                typeHashPos,
-                416 /* 32 * 12 */
-            )
+            structHash := keccak256(typeHashPos, 416 /* 32 * 12 */)
 
             mstore(typeHashPos, typeHashMemBefore)
             mstore(feesHashPos, feesHashMemBefore)

--- a/contracts/zero-ex/contracts/src/features/multiplex/MultiplexFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/multiplex/MultiplexFeature.sol
@@ -54,7 +54,7 @@ contract MultiplexFeature is
     /// @dev Version of this feature.
     uint256 public immutable override FEATURE_VERSION = _encodeVersion(2, 0, 0);
     /// @dev The highest bit of a uint256 value.
-    uint256 private constant HIGH_BIT = 2**255;
+    uint256 private constant HIGH_BIT = 2 ** 255;
     /// @dev Mask of the lower 255 bits of a uint256 value.
     uint256 private constant LOWER_255_BITS = HIGH_BIT - 1;
 
@@ -191,10 +191,10 @@ contract MultiplexFeature is
     /// @param minBuyAmount The minimum amount of `outputToken` that
     ///        must be bought for this function to not revert.
     /// @return boughtAmount The amount of `outputToken` bought.
-    function _multiplexBatchSell(BatchSellParams memory params, uint256 minBuyAmount)
-        private
-        returns (uint256 boughtAmount)
-    {
+    function _multiplexBatchSell(
+        BatchSellParams memory params,
+        uint256 minBuyAmount
+    ) private returns (uint256 boughtAmount) {
         // Cache the recipient's initial balance of the output token.
         uint256 balanceBefore = params.outputToken.balanceOf(params.recipient);
         // Execute the batch sell.
@@ -320,10 +320,10 @@ contract MultiplexFeature is
     /// @param minBuyAmount The minimum amount of output tokens that
     ///        must be bought for this function to not revert.
     /// @return boughtAmount The amount of output tokens bought.
-    function _multiplexMultiHopSell(MultiHopSellParams memory params, uint256 minBuyAmount)
-        private
-        returns (uint256 boughtAmount)
-    {
+    function _multiplexMultiHopSell(
+        MultiHopSellParams memory params,
+        uint256 minBuyAmount
+    ) private returns (uint256 boughtAmount) {
         // There should be one call/hop between every two tokens
         // in the path.
         // tokens[0]––calls[0]––>tokens[1]––...––calls[n-1]––>tokens[n]

--- a/contracts/zero-ex/contracts/src/features/multiplex/MultiplexUniswapV3.sol
+++ b/contracts/zero-ex/contracts/src/features/multiplex/MultiplexUniswapV3.sol
@@ -73,9 +73,10 @@ abstract contract MultiplexUniswapV3 is FixinTokenSpender {
         }
     }
 
-    function _multiHopSellUniswapV3(IMultiplexFeature.MultiHopSellState memory state, bytes memory wrappedCallData)
-        internal
-    {
+    function _multiHopSellUniswapV3(
+        IMultiplexFeature.MultiHopSellState memory state,
+        bytes memory wrappedCallData
+    ) internal {
         bool success;
         bytes memory resultData;
         if (state.from == address(this)) {

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersCancellation.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersCancellation.sol
@@ -85,11 +85,7 @@ abstract contract NativeOrdersCancellation is INativeOrdersEvents, NativeOrdersI
     /// @param makerToken The maker token.
     /// @param takerToken The taker token.
     /// @param minValidSalt The new minimum valid salt.
-    function cancelPairLimitOrders(
-        IERC20TokenV06 makerToken,
-        IERC20TokenV06 takerToken,
-        uint256 minValidSalt
-    ) public {
+    function cancelPairLimitOrders(IERC20TokenV06 makerToken, IERC20TokenV06 takerToken, uint256 minValidSalt) public {
         _cancelPairLimitOrders(msg.sender, makerToken, takerToken, minValidSalt);
     }
 
@@ -172,11 +168,7 @@ abstract contract NativeOrdersCancellation is INativeOrdersEvents, NativeOrdersI
     /// @param makerToken The maker token.
     /// @param takerToken The taker token.
     /// @param minValidSalt The new minimum valid salt.
-    function cancelPairRfqOrders(
-        IERC20TokenV06 makerToken,
-        IERC20TokenV06 takerToken,
-        uint256 minValidSalt
-    ) public {
+    function cancelPairRfqOrders(IERC20TokenV06 makerToken, IERC20TokenV06 takerToken, uint256 minValidSalt) public {
         _cancelPairRfqOrders(msg.sender, makerToken, takerToken, minValidSalt);
     }
 

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersInfo.sol
@@ -51,11 +51,9 @@ abstract contract NativeOrdersInfo is FixinEIP712, FixinTokenSpender {
     /// @dev Get the order info for a limit order.
     /// @param order The limit order.
     /// @return orderInfo Info about the order.
-    function getLimitOrderInfo(LibNativeOrder.LimitOrder memory order)
-        public
-        view
-        returns (LibNativeOrder.OrderInfo memory orderInfo)
-    {
+    function getLimitOrderInfo(
+        LibNativeOrder.LimitOrder memory order
+    ) public view returns (LibNativeOrder.OrderInfo memory orderInfo) {
         // Recover maker and compute order hash.
         orderInfo.orderHash = getLimitOrderHash(order);
         uint256 minValidSalt = LibNativeOrdersStorage
@@ -69,11 +67,9 @@ abstract contract NativeOrdersInfo is FixinEIP712, FixinTokenSpender {
     /// @dev Get the order info for an RFQ order.
     /// @param order The RFQ order.
     /// @return orderInfo Info about the order.
-    function getRfqOrderInfo(LibNativeOrder.RfqOrder memory order)
-        public
-        view
-        returns (LibNativeOrder.OrderInfo memory orderInfo)
-    {
+    function getRfqOrderInfo(
+        LibNativeOrder.RfqOrder memory order
+    ) public view returns (LibNativeOrder.OrderInfo memory orderInfo) {
         // Recover maker and compute order hash.
         orderInfo.orderHash = getRfqOrderHash(order);
         uint256 minValidSalt = LibNativeOrdersStorage
@@ -145,7 +141,10 @@ abstract contract NativeOrdersInfo is FixinEIP712, FixinTokenSpender {
     /// @return actualFillableTakerTokenAmount How much of the order is fillable
     ///         based on maker funds, in taker tokens.
     /// @return isSignatureValid Whether the signature is valid.
-    function getRfqOrderRelevantState(LibNativeOrder.RfqOrder memory order, LibSignature.Signature memory signature)
+    function getRfqOrderRelevantState(
+        LibNativeOrder.RfqOrder memory order,
+        LibSignature.Signature memory signature
+    )
         public
         view
         returns (
@@ -293,11 +292,9 @@ abstract contract NativeOrdersInfo is FixinEIP712, FixinTokenSpender {
 
     /// @dev Calculate the actual fillable taker token amount of an order
     ///      based on maker allowance and balances.
-    function _getActualFillableTakerTokenAmount(GetActualFillableTakerTokenAmountParams memory params)
-        private
-        view
-        returns (uint128 actualFillableTakerTokenAmount)
-    {
+    function _getActualFillableTakerTokenAmount(
+        GetActualFillableTakerTokenAmountParams memory params
+    ) private view returns (uint128 actualFillableTakerTokenAmount) {
         if (params.orderMakerAmount == 0 || params.orderTakerAmount == 0) {
             // Empty order.
             return 0;

--- a/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
+++ b/contracts/zero-ex/contracts/src/features/native_orders/NativeOrdersSettlement.sol
@@ -313,10 +313,9 @@ abstract contract NativeOrdersSettlement is
     /// @dev Fill a limit order. Private variant. Does not refund protocol fees.
     /// @param params Function params.
     /// @return results Results of the fill.
-    function _fillLimitOrderPrivate(FillLimitOrderPrivateParams memory params)
-        private
-        returns (FillNativeOrderResults memory results)
-    {
+    function _fillLimitOrderPrivate(
+        FillLimitOrderPrivateParams memory params
+    ) private returns (FillNativeOrderResults memory results) {
         LibNativeOrder.OrderInfo memory orderInfo = getLimitOrderInfo(params.order);
 
         // Must be fillable.
@@ -402,10 +401,9 @@ abstract contract NativeOrdersSettlement is
     /// @dev Fill an RFQ order. Private variant.
     /// @param params Function params.
     /// @return results Results of the fill.
-    function _fillRfqOrderPrivate(FillRfqOrderPrivateParams memory params)
-        private
-        returns (FillNativeOrderResults memory results)
-    {
+    function _fillRfqOrderPrivate(
+        FillRfqOrderPrivateParams memory params
+    ) private returns (FillNativeOrderResults memory results) {
         LibNativeOrder.OrderInfo memory orderInfo = getRfqOrderInfo(params.order);
 
         // Must be fillable.
@@ -473,10 +471,9 @@ abstract contract NativeOrdersSettlement is
     /// @param settleInfo Information needed to execute the settlement.
     /// @return takerTokenFilledAmount How much taker token was filled.
     /// @return makerTokenFilledAmount How much maker token was filled.
-    function _settleOrder(SettleOrderInfo memory settleInfo)
-        private
-        returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount)
-    {
+    function _settleOrder(
+        SettleOrderInfo memory settleInfo
+    ) private returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount) {
         // Clamp the taker token fill amount to the fillable amount.
         takerTokenFilledAmount = LibSafeMathV06.min128(
             settleInfo.takerTokenFillAmount,

--- a/contracts/zero-ex/contracts/src/features/nft_orders/ERC1155OrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/nft_orders/ERC1155OrdersFeature.sol
@@ -251,7 +251,7 @@ contract ERC1155OrdersFeature is IFeature, IERC1155OrdersFeature, FixinERC1155Sp
     ///         indicating that the callback succeeded.
     function onERC1155Received(
         address operator,
-        address, /* from */
+        address /* from */,
         uint256 tokenId,
         uint256 value,
         bytes calldata data
@@ -422,7 +422,7 @@ contract ERC1155OrdersFeature is IFeature, IERC1155OrdersFeature, FixinERC1155Sp
     /// @param fillAmount The amount (denominated in the NFT asset)
     ///        that the order has been filled by.
     function _updateOrderState(
-        LibNFTOrder.NFTOrder memory, /* order */
+        LibNFTOrder.NFTOrder memory /* order */,
         bytes32 orderHash,
         uint128 fillAmount
     ) internal override {
@@ -442,23 +442,19 @@ contract ERC1155OrdersFeature is IFeature, IERC1155OrdersFeature, FixinERC1155Sp
     ///      an ERC1155 asset.
     /// @param order The ERC1155 order.
     /// @param erc1155TokenId The ID of the ERC1155 asset.
-    function validateERC1155OrderProperties(LibNFTOrder.ERC1155Order memory order, uint256 erc1155TokenId)
-        public
-        view
-        override
-    {
+    function validateERC1155OrderProperties(
+        LibNFTOrder.ERC1155Order memory order,
+        uint256 erc1155TokenId
+    ) public view override {
         _validateOrderProperties(order.asNFTOrder(), erc1155TokenId);
     }
 
     /// @dev Get the order info for an ERC1155 order.
     /// @param order The ERC1155 order.
     /// @return orderInfo Info about the order.
-    function getERC1155OrderInfo(LibNFTOrder.ERC1155Order memory order)
-        public
-        view
-        override
-        returns (LibNFTOrder.OrderInfo memory orderInfo)
-    {
+    function getERC1155OrderInfo(
+        LibNFTOrder.ERC1155Order memory order
+    ) public view override returns (LibNFTOrder.OrderInfo memory orderInfo) {
         orderInfo.orderAmount = order.erc1155TokenAmount;
         orderInfo.orderHash = getERC1155OrderHash(order);
 
@@ -511,24 +507,18 @@ contract ERC1155OrdersFeature is IFeature, IERC1155OrdersFeature, FixinERC1155Sp
     /// @dev Get the order info for an NFT order.
     /// @param order The NFT order.
     /// @return orderInfo Info about the order.
-    function _getOrderInfo(LibNFTOrder.NFTOrder memory order)
-        internal
-        view
-        override
-        returns (LibNFTOrder.OrderInfo memory orderInfo)
-    {
+    function _getOrderInfo(
+        LibNFTOrder.NFTOrder memory order
+    ) internal view override returns (LibNFTOrder.OrderInfo memory orderInfo) {
         return getERC1155OrderInfo(order.asERC1155Order());
     }
 
     /// @dev Get the EIP-712 hash of an ERC1155 order.
     /// @param order The ERC1155 order.
     /// @return orderHash The order hash.
-    function getERC1155OrderHash(LibNFTOrder.ERC1155Order memory order)
-        public
-        view
-        override
-        returns (bytes32 orderHash)
-    {
+    function getERC1155OrderHash(
+        LibNFTOrder.ERC1155Order memory order
+    ) public view override returns (bytes32 orderHash) {
         return _getEIP712Hash(LibNFTOrder.getERC1155OrderStructHash(order));
     }
 }

--- a/contracts/zero-ex/contracts/src/features/nft_orders/ERC721OrdersFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/nft_orders/ERC721OrdersFeature.sol
@@ -474,7 +474,7 @@ contract ERC721OrdersFeature is IFeature, IERC721OrdersFeature, FixinERC721Spend
     ///         indicating that the callback succeeded.
     function onERC721Received(
         address operator,
-        address, /* from */
+        address /* from */,
         uint256 tokenId,
         bytes calldata data
     ) external override returns (bytes4 success) {
@@ -599,11 +599,10 @@ contract ERC721OrdersFeature is IFeature, IERC721OrdersFeature, FixinERC721Spend
     ///      the given ERC721 order. Reverts if not.
     /// @param order The ERC721 order.
     /// @param signature The signature to validate.
-    function validateERC721OrderSignature(LibNFTOrder.ERC721Order memory order, LibSignature.Signature memory signature)
-        public
-        view
-        override
-    {
+    function validateERC721OrderSignature(
+        LibNFTOrder.ERC721Order memory order,
+        LibSignature.Signature memory signature
+    ) public view override {
         bytes32 orderHash = getERC721OrderHash(order);
         _validateOrderSignature(orderHash, signature, order.maker);
     }
@@ -658,7 +657,7 @@ contract ERC721OrdersFeature is IFeature, IERC721OrdersFeature, FixinERC721Spend
     ///        that the order has been filled by.
     function _updateOrderState(
         LibNFTOrder.NFTOrder memory order,
-        bytes32, /* orderHash */
+        bytes32 /* orderHash */,
         uint128 fillAmount
     ) internal override {
         assert(fillAmount == 1);
@@ -682,23 +681,19 @@ contract ERC721OrdersFeature is IFeature, IERC721OrdersFeature, FixinERC721Spend
     ///      an ERC721 asset.
     /// @param order The ERC721 order.
     /// @param erc721TokenId The ID of the ERC721 asset.
-    function validateERC721OrderProperties(LibNFTOrder.ERC721Order memory order, uint256 erc721TokenId)
-        public
-        view
-        override
-    {
+    function validateERC721OrderProperties(
+        LibNFTOrder.ERC721Order memory order,
+        uint256 erc721TokenId
+    ) public view override {
         _validateOrderProperties(order.asNFTOrder(), erc721TokenId);
     }
 
     /// @dev Get the current status of an ERC721 order.
     /// @param order The ERC721 order.
     /// @return status The status of the order.
-    function getERC721OrderStatus(LibNFTOrder.ERC721Order memory order)
-        public
-        view
-        override
-        returns (LibNFTOrder.OrderStatus status)
-    {
+    function getERC721OrderStatus(
+        LibNFTOrder.ERC721Order memory order
+    ) public view override returns (LibNFTOrder.OrderStatus status) {
         // Only buy orders with `erc721TokenId` == 0 can be property
         // orders.
         if (
@@ -741,12 +736,9 @@ contract ERC721OrdersFeature is IFeature, IERC721OrdersFeature, FixinERC721Spend
     /// @dev Get the order info for an NFT order.
     /// @param order The NFT order.
     /// @return orderInfo Info about the order.
-    function _getOrderInfo(LibNFTOrder.NFTOrder memory order)
-        internal
-        view
-        override
-        returns (LibNFTOrder.OrderInfo memory orderInfo)
-    {
+    function _getOrderInfo(
+        LibNFTOrder.NFTOrder memory order
+    ) internal view override returns (LibNFTOrder.OrderInfo memory orderInfo) {
         LibNFTOrder.ERC721Order memory erc721Order = order.asERC721Order();
         orderInfo.orderHash = getERC721OrderHash(erc721Order);
         orderInfo.status = getERC721OrderStatus(erc721Order);
@@ -770,12 +762,10 @@ contract ERC721OrdersFeature is IFeature, IERC721OrdersFeature, FixinERC721Spend
     ///        248 bits.
     /// @return bitVector The order status bit vector for the
     ///         given maker and nonce range.
-    function getERC721OrderStatusBitVector(address maker, uint248 nonceRange)
-        external
-        view
-        override
-        returns (uint256 bitVector)
-    {
+    function getERC721OrderStatusBitVector(
+        address maker,
+        uint248 nonceRange
+    ) external view override returns (uint256 bitVector) {
         LibERC721OrdersStorage.Storage storage stor = LibERC721OrdersStorage.getStorage();
         return stor.orderStatusByMaker[maker][nonceRange];
     }

--- a/contracts/zero-ex/contracts/src/features/nft_orders/NFTOrders.sol
+++ b/contracts/zero-ex/contracts/src/features/nft_orders/NFTOrders.sol
@@ -439,9 +439,7 @@ abstract contract NFTOrders is FixinCommon, FixinEIP712, FixinTokenSpender {
     /// @dev Get the order info for an NFT order.
     /// @param order The NFT order.
     /// @return orderInfo Info about the order.
-    function _getOrderInfo(LibNFTOrder.NFTOrder memory order)
-        internal
-        view
-        virtual
-        returns (LibNFTOrder.OrderInfo memory orderInfo);
+    function _getOrderInfo(
+        LibNFTOrder.NFTOrder memory order
+    ) internal view virtual returns (LibNFTOrder.OrderInfo memory orderInfo);
 }

--- a/contracts/zero-ex/contracts/src/fixins/FixinERC721Spender.sol
+++ b/contracts/zero-ex/contracts/src/fixins/FixinERC721Spender.sol
@@ -33,12 +33,7 @@ abstract contract FixinERC721Spender {
     /// @param owner The owner of the asset.
     /// @param to The recipient of the asset.
     /// @param tokenId The token ID of the asset to transfer.
-    function _transferERC721AssetFrom(
-        IERC721Token token,
-        address owner,
-        address to,
-        uint256 tokenId
-    ) internal {
+    function _transferERC721AssetFrom(IERC721Token token, address owner, address to, uint256 tokenId) internal {
         require(address(token) != address(this), "FixinERC721Spender/CANNOT_INVOKE_SELF");
 
         assembly {

--- a/contracts/zero-ex/contracts/src/fixins/FixinTokenSpender.sol
+++ b/contracts/zero-ex/contracts/src/fixins/FixinTokenSpender.sol
@@ -33,12 +33,7 @@ abstract contract FixinTokenSpender {
     /// @param owner The owner of the tokens.
     /// @param to The recipient of the tokens.
     /// @param amount The amount of `token` to transfer.
-    function _transferERC20TokensFrom(
-        IERC20TokenV06 token,
-        address owner,
-        address to,
-        uint256 amount
-    ) internal {
+    function _transferERC20TokensFrom(IERC20TokenV06 token, address owner, address to, uint256 amount) internal {
         require(address(token) != address(this), "FixinTokenSpender/CANNOT_INVOKE_SELF");
 
         assembly {
@@ -79,11 +74,7 @@ abstract contract FixinTokenSpender {
     /// @param token The token to spend.
     /// @param to The recipient of the tokens.
     /// @param amount The amount of `token` to transfer.
-    function _transferERC20Tokens(
-        IERC20TokenV06 token,
-        address to,
-        uint256 amount
-    ) internal {
+    function _transferERC20Tokens(IERC20TokenV06 token, address to, uint256 amount) internal {
         require(address(token) != address(this), "FixinTokenSpender/CANNOT_INVOKE_SELF");
 
         assembly {

--- a/contracts/zero-ex/contracts/src/liquidity-providers/CurveLiquidityProvider.sol
+++ b/contracts/zero-ex/contracts/src/liquidity-providers/CurveLiquidityProvider.sol
@@ -131,8 +131,8 @@ contract CurveLiquidityProvider is ILiquidityProvider {
     /// @dev Quotes the amount of `outputToken` that would be obtained by
     ///      selling `sellAmount` of `inputToken`.
     function getSellQuote(
-        IERC20TokenV06, /* inputToken */
-        IERC20TokenV06, /* outputToken */
+        IERC20TokenV06 /* inputToken */,
+        IERC20TokenV06 /* outputToken */,
         uint256 /* sellAmount */
     ) external view override returns (uint256) {
         revert("CurveLiquidityProvider/NOT_IMPLEMENTED");

--- a/contracts/zero-ex/contracts/src/liquidity-providers/MooniswapLiquidityProvider.sol
+++ b/contracts/zero-ex/contracts/src/liquidity-providers/MooniswapLiquidityProvider.sol
@@ -128,8 +128,8 @@ contract MooniswapLiquidityProvider is ILiquidityProvider {
     /// @dev Quotes the amount of `outputToken` that would be obtained by
     ///      selling `sellAmount` of `inputToken`.
     function getSellQuote(
-        IERC20TokenV06, /* inputToken */
-        IERC20TokenV06, /* outputToken */
+        IERC20TokenV06 /* inputToken */,
+        IERC20TokenV06 /* outputToken */,
         uint256 /* sellAmount */
     ) external view override returns (uint256) {
         revert("MooniswapLiquidityProvider/NOT_IMPLEMENTED");

--- a/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
+++ b/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
@@ -114,11 +114,7 @@ contract FullMigration {
     /// @param zeroEx The bootstrapped ZeroEx contract.
     /// @param features Features to add to the proxy.
     /// @param migrateOpts Parameters needed to initialize features.
-    function _addFeatures(
-        ZeroEx zeroEx,
-        Features memory features,
-        MigrateOpts memory migrateOpts
-    ) private {
+    function _addFeatures(ZeroEx zeroEx, Features memory features, MigrateOpts memory migrateOpts) private {
         IOwnableFeature ownable = IOwnableFeature(address(zeroEx));
         // TransformERC20Feature
         {

--- a/contracts/zero-ex/contracts/src/transformers/FillQuoteTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/FillQuoteTransformer.sol
@@ -138,7 +138,7 @@ contract FillQuoteTransformer is Transformer {
     event ProtocolFeeUnfunded(bytes32 orderHash);
 
     /// @dev The highest bit of a uint256 value.
-    uint256 private constant HIGH_BIT = 2**255;
+    uint256 private constant HIGH_BIT = 2 ** 255;
     /// @dev Mask of the lower 255 bits of a uint256 value.
     uint256 private constant LOWER_255_BITS = HIGH_BIT - 1;
     /// @dev If `refundReceiver` is set to this address, unpsent

--- a/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
@@ -40,11 +40,7 @@ library LibERC20Transformer {
     /// @param token An ERC20 or the ETH pseudo-token address (`ETH_TOKEN_ADDRESS`).
     /// @param to The recipient.
     /// @param amount The transfer amount.
-    function transformerTransfer(
-        IERC20TokenV06 token,
-        address payable to,
-        uint256 amount
-    ) internal {
+    function transformerTransfer(IERC20TokenV06 token, address payable to, uint256 amount) internal {
         if (isTokenETH(token)) {
             to.transfer(amount);
         } else {
@@ -57,11 +53,7 @@ library LibERC20Transformer {
     /// @param token An ERC20 or the ETH pseudo-token address (`ETH_TOKEN_ADDRESS`).
     /// @param to The recipient.
     /// @param amount The transfer amount.
-    function unsafeTransformerTransfer(
-        IERC20TokenV06 token,
-        address payable to,
-        uint256 amount
-    ) internal {
+    function unsafeTransformerTransfer(IERC20TokenV06 token, address payable to, uint256 amount) internal {
         if (isTokenETH(token)) {
             (bool sent, ) = to.call{value: amount}("");
             require(sent, "LibERC20Transformer/FAILED_TO_SEND_ETHER");
@@ -130,11 +122,10 @@ library LibERC20Transformer {
     /// @param deploymentNonce The nonce that the deployer had when deploying
     ///        a contract.
     /// @return deploymentAddress The deployment address.
-    function getDeployedAddress(address deployer, uint32 deploymentNonce)
-        internal
-        pure
-        returns (address payable deploymentAddress)
-    {
+    function getDeployedAddress(
+        address deployer,
+        uint32 deploymentNonce
+    ) internal pure returns (address payable deploymentAddress) {
         // The address of if a deployed contract is the lower 20 bytes of the
         // hash of the RLP-encoded deployer's account address + account nonce.
         // See: https://ethereum.stackexchange.com/questions/760/how-is-the-address-of-an-ethereum-contract-computed

--- a/contracts/zero-ex/contracts/src/transformers/bridges/EthereumBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/EthereumBridgeAdapter.sol
@@ -72,7 +72,9 @@ contract EthereumBridgeAdapter is
     MixinUniswapV3,
     MixinZeroExBridge
 {
-    constructor(IEtherTokenV06 weth)
+    constructor(
+        IEtherTokenV06 weth
+    )
         public
         MixinBancor(weth)
         MixinBancorV3(weth)

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinAaveV2.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinAaveV2.sol
@@ -36,12 +36,7 @@ interface ILendingPool {
      * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
      *   0 if the action is executed directly by the user, without any middle-man
      **/
-    function deposit(
-        address asset,
-        uint256 amount,
-        address onBehalfOf,
-        uint16 referralCode
-    ) external;
+    function deposit(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
 
     /**
      * @dev Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
@@ -54,11 +49,7 @@ interface ILendingPool {
      *   different wallet
      * @return The final amount withdrawn
      **/
-    function withdraw(
-        address asset,
-        uint256 amount,
-        address to
-    ) external returns (uint256);
+    function withdraw(address asset, uint256 amount, address to) external returns (uint256);
 }
 
 contract MixinAaveV2 {

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinBalancerV2Batch.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinBalancerV2Batch.sol
@@ -63,10 +63,10 @@ contract MixinBalancerV2Batch {
         IERC20TokenV06[] assets;
     }
 
-    function _tradeBalancerV2Batch(uint256 sellAmount, bytes memory bridgeData)
-        internal
-        returns (uint256 boughtAmount)
-    {
+    function _tradeBalancerV2Batch(
+        uint256 sellAmount,
+        bytes memory bridgeData
+    ) internal returns (uint256 boughtAmount) {
         // Decode the bridge data.
         (
             IBalancerV2BatchSwapVault vault,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinDodo.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinDodo.sol
@@ -26,17 +26,9 @@ import "@0x/contracts-erc20/contracts/src/v06/IERC20TokenV06.sol";
 import "../IBridgeAdapter.sol";
 
 interface IDODO {
-    function sellBaseToken(
-        uint256 amount,
-        uint256 minReceiveQuote,
-        bytes calldata data
-    ) external returns (uint256);
+    function sellBaseToken(uint256 amount, uint256 minReceiveQuote, bytes calldata data) external returns (uint256);
 
-    function buyBaseToken(
-        uint256 amount,
-        uint256 maxPayQuote,
-        bytes calldata data
-    ) external returns (uint256);
+    function buyBaseToken(uint256 amount, uint256 maxPayQuote, bytes calldata data) external returns (uint256);
 }
 
 interface IDODOHelper {

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinGMX.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinGMX.sol
@@ -33,12 +33,7 @@ interface IGmxRouter {
     /// @param _amountIn The amount of input tokens to send.
     /// @param _minOut The minimum amount of output tokens that must be received for the transaction not to revert.
     /// @param _receiver Recipient of the output tokens.
-    function swap(
-        address[] calldata _path,
-        uint256 _amountIn,
-        uint256 _minOut,
-        address _receiver
-    ) external;
+    function swap(address[] calldata _path, uint256 _amountIn, uint256 _minOut, address _receiver) external;
 }
 
 contract MixinGMX {

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinMakerPSM.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinMakerPSM.sol
@@ -63,11 +63,11 @@ contract MixinMakerPSM {
 
     // Maker units
     // wad: fixed point decimal with 18 decimals (for basic quantities, e.g. balances)
-    uint256 private constant WAD = 10**18;
+    uint256 private constant WAD = 10 ** 18;
     // ray: fixed point decimal with 27 decimals (for precise quantites, e.g. ratios)
-    uint256 private constant RAY = 10**27;
+    uint256 private constant RAY = 10 ** 27;
     // rad: fixed point decimal with 45 decimals (result of integer multiplication with a wad and a ray)
-    uint256 private constant RAD = 10**45;
+    uint256 private constant RAD = 10 ** 45;
 
     // See https://github.com/makerdao/dss/blob/master/DEVELOPING.md
 
@@ -89,7 +89,7 @@ contract MixinMakerPSM {
             psm.sellGem(address(this), sellAmount);
         } else if (address(buyToken) == data.gemTokenAddres) {
             uint256 feeDivisor = WAD.safeAdd(psm.tout()); // eg. 1.001 * 10 ** 18 with 0.1% fee [tout is in wad];
-            uint256 buyTokenBaseUnit = uint256(10)**uint256(buyToken.decimals());
+            uint256 buyTokenBaseUnit = uint256(10) ** uint256(buyToken.decimals());
             uint256 gemAmount = sellAmount.safeMul(buyTokenBaseUnit).safeDiv(feeDivisor);
 
             sellToken.approveIfBelow(data.psmAddress, sellAmount);

--- a/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinWOOFi.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/mixins/MixinWOOFi.sol
@@ -80,12 +80,7 @@ contract MixinWOOFi {
         boughtAmount = buyToken.balanceOf(address(this)).safeSub(beforeBalance);
     }
 
-    function _swap(
-        uint256 _amountIn,
-        address _tokenIn,
-        address _tokenOut,
-        IWooPP pool
-    ) internal {
+    function _swap(uint256 _amountIn, address _tokenIn, address _tokenOut, IWooPP pool) internal {
         address quoteToken = pool.quoteToken();
         if (_tokenIn == quoteToken) {
             pool.sellQuote(_tokenOut, _amountIn, 1, address(this), rebateAddress);

--- a/contracts/zero-ex/contracts/src/vendor/IERC1155Token.sol
+++ b/contracts/zero-ex/contracts/src/vendor/IERC1155Token.sol
@@ -71,13 +71,7 @@ interface IERC1155Token {
     /// @param id      ID of the token type
     /// @param value   Transfer amount
     /// @param data    Additional data with no specified format, sent in call to `_to`
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 id,
-        uint256 value,
-        bytes calldata data
-    ) external;
+    function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes calldata data) external;
 
     /// @notice Send multiple types of Tokens from a 3rd party in one transfer (with safety call).
     /// @dev MUST emit TransferBatch event on success.
@@ -124,8 +118,8 @@ interface IERC1155Token {
     /// @param owners      The addresses of the token holders
     /// @param ids         ID of the Tokens
     /// @return balances_  The _owner's balance of the Token types requested
-    function balanceOfBatch(address[] calldata owners, uint256[] calldata ids)
-        external
-        view
-        returns (uint256[] memory balances_);
+    function balanceOfBatch(
+        address[] calldata owners,
+        uint256[] calldata ids
+    ) external view returns (uint256[] memory balances_);
 }

--- a/contracts/zero-ex/contracts/src/vendor/IERC721Token.sol
+++ b/contracts/zero-ex/contracts/src/vendor/IERC721Token.sol
@@ -49,12 +49,7 @@ interface IERC721Token {
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
     /// @param _data Additional data with no specified format, sent in call to `_to`
-    function safeTransferFrom(
-        address _from,
-        address _to,
-        uint256 _tokenId,
-        bytes calldata _data
-    ) external;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes calldata _data) external;
 
     /// @notice Transfers the ownership of an NFT from one address to another address
     /// @dev This works identically to the other function with an extra data parameter,
@@ -62,11 +57,7 @@ interface IERC721Token {
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    function safeTransferFrom(
-        address _from,
-        address _to,
-        uint256 _tokenId
-    ) external;
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external;
 
     /// @notice Change or reaffirm the approved address for an NFT
     /// @dev The zero address indicates there is no approved address.
@@ -101,11 +92,7 @@ interface IERC721Token {
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _tokenId
-    ) external;
+    function transferFrom(address _from, address _to, uint256 _tokenId) external;
 
     /// @notice Find the owner of an NFT
     /// @dev NFTs assigned to zero address are considered invalid, and queries

--- a/contracts/zero-ex/contracts/src/vendor/IPropertyValidator.sol
+++ b/contracts/zero-ex/contracts/src/vendor/IPropertyValidator.sol
@@ -26,9 +26,5 @@ interface IPropertyValidator {
     /// @param tokenAddress The ERC721/ERC1155 token contract address.
     /// @param tokenId The ERC721/ERC1155 tokenId of the asset to check.
     /// @param propertyData Encoded properties or auxiliary data needed to perform the check.
-    function validateProperty(
-        address tokenAddress,
-        uint256 tokenId,
-        bytes calldata propertyData
-    ) external view;
+    function validateProperty(address tokenAddress, uint256 tokenId, bytes calldata propertyData) external view;
 }

--- a/contracts/zero-ex/contracts/src/vendor/IUniswapV2Pair.sol
+++ b/contracts/zero-ex/contracts/src/vendor/IUniswapV2Pair.sol
@@ -29,19 +29,7 @@ interface IUniswapV2Pair {
         address indexed to
     );
 
-    function swap(
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address to,
-        bytes calldata data
-    ) external;
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
 
-    function getReserves()
-        external
-        view
-        returns (
-            uint112 reserve0,
-            uint112 reserve1,
-            uint32 blockTimestampLast
-        );
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
 }

--- a/contracts/zero-ex/contracts/src/vendor/v3/IStaking.sol
+++ b/contracts/zero-ex/contracts/src/vendor/v3/IStaking.sol
@@ -22,9 +22,5 @@ pragma solidity ^0.6.5;
 interface IStaking {
     function joinStakingPoolAsMaker(bytes32) external;
 
-    function payProtocolFee(
-        address,
-        address,
-        uint256
-    ) external payable;
+    function payProtocolFee(address, address, uint256) external payable;
 }

--- a/contracts/zero-ex/contracts/test/TestFillQuoteTransformerBridge.sol
+++ b/contracts/zero-ex/contracts/test/TestFillQuoteTransformerBridge.sol
@@ -28,10 +28,10 @@ contract TestFillQuoteTransformerBridge {
     uint256 private constant REVERT_AMOUNT = 0xdeadbeef;
 
     function sellTokenForToken(
-        address, /* takerToken */
+        address /* takerToken */,
         address makerToken,
         address recipient,
-        uint256, /* minBuyAmount */
+        uint256 /* minBuyAmount */,
         bytes calldata auxiliaryData
     ) external returns (uint256 boughtAmount) {
         boughtAmount = abi.decode(auxiliaryData, (uint256));

--- a/contracts/zero-ex/contracts/test/TestFixinTokenSpender.sol
+++ b/contracts/zero-ex/contracts/test/TestFixinTokenSpender.sol
@@ -26,12 +26,7 @@ import "../src/fixins/FixinTokenSpender.sol";
 contract TestFixinTokenSpender is FixinTokenSpender {
     constructor() public {}
 
-    function transferERC20TokensFrom(
-        IERC20TokenV06 token,
-        address owner,
-        address to,
-        uint256 amount
-    ) external {
+    function transferERC20TokensFrom(IERC20TokenV06 token, address owner, address to, uint256 amount) external {
         _transferERC20TokensFrom(token, owner, to, amount);
     }
 

--- a/contracts/zero-ex/contracts/test/TestLibNativeOrder.sol
+++ b/contracts/zero-ex/contracts/test/TestLibNativeOrder.sol
@@ -5,11 +5,9 @@ pragma experimental ABIEncoderV2;
 import "../src/features/libs/LibNativeOrder.sol";
 
 contract TestLibNativeOrder {
-    function getLimitOrderStructHash(LibNativeOrder.LimitOrder calldata order)
-        external
-        pure
-        returns (bytes32 structHash)
-    {
+    function getLimitOrderStructHash(
+        LibNativeOrder.LimitOrder calldata order
+    ) external pure returns (bytes32 structHash) {
         return LibNativeOrder.getLimitOrderStructHash(order);
     }
 

--- a/contracts/zero-ex/contracts/test/TestLibSignature.sol
+++ b/contracts/zero-ex/contracts/test/TestLibSignature.sol
@@ -23,11 +23,10 @@ pragma experimental ABIEncoderV2;
 import "../src/features/libs/LibSignature.sol";
 
 contract TestLibSignature {
-    function getSignerOfHash(bytes32 hash, LibSignature.Signature calldata signature)
-        external
-        pure
-        returns (address signer)
-    {
+    function getSignerOfHash(
+        bytes32 hash,
+        LibSignature.Signature calldata signature
+    ) external pure returns (address signer) {
         return LibSignature.getSignerOfHash(hash, signature);
     }
 }

--- a/contracts/zero-ex/contracts/test/TestMetaTransactionsNativeOrdersFeature.sol
+++ b/contracts/zero-ex/contracts/test/TestMetaTransactionsNativeOrdersFeature.sol
@@ -82,7 +82,7 @@ contract TestMetaTransactionsNativeOrdersFeature is NativeOrdersFeature {
         LibSignature.Signature memory signature,
         uint128 takerTokenFillAmount,
         address taker,
-        bool, /* useSelfBalance */
+        bool /* useSelfBalance */,
         address /* recipient */
     ) public override returns (uint128 takerTokenFilledAmount, uint128 makerTokenFilledAmount) {
         emit FillRfqOrderCalled(

--- a/contracts/zero-ex/contracts/test/TestMetaTransactionsTransformERC20Feature.sol
+++ b/contracts/zero-ex/contracts/test/TestMetaTransactionsTransformERC20Feature.sol
@@ -37,12 +37,9 @@ contract TestMetaTransactionsTransformERC20Feature is TransformERC20Feature {
 
     constructor() public TransformERC20Feature() {}
 
-    function _transformERC20(TransformERC20Args memory args)
-        public
-        payable
-        override
-        returns (uint256 outputTokenAmount)
-    {
+    function _transformERC20(
+        TransformERC20Args memory args
+    ) public payable override returns (uint256 outputTokenAmount) {
         if (msg.value == 555) {
             tx.origin.transfer(1);
         }

--- a/contracts/zero-ex/contracts/test/TestOrderSignerRegistryWithContractWallet.sol
+++ b/contracts/zero-ex/contracts/test/TestOrderSignerRegistryWithContractWallet.sol
@@ -35,11 +35,7 @@ contract TestOrderSignerRegistryWithContractWallet is OwnableV06 {
         zeroex.registerAllowedOrderSigner(signer, allowed);
     }
 
-    function approveERC20(
-        IERC20TokenV06 token,
-        address spender,
-        uint256 value
-    ) external onlyOwner {
+    function approveERC20(IERC20TokenV06 token, address spender, uint256 value) external onlyOwner {
         token.approve(spender, value);
     }
 }

--- a/contracts/zero-ex/contracts/test/TestPropertyValidator.sol
+++ b/contracts/zero-ex/contracts/test/TestPropertyValidator.sol
@@ -21,11 +21,7 @@ pragma solidity ^0.6.5;
 pragma experimental ABIEncoderV2;
 
 contract TestPropertyValidator {
-    function validateProperty(
-        address tokenAddress,
-        uint256 tokenId,
-        bytes calldata propertyData
-    ) external view {
+    function validateProperty(address tokenAddress, uint256 tokenId, bytes calldata propertyData) external view {
         require(propertyData.length > 0, "TestPropertyValidator::validateProperty/REVERT");
     }
 }

--- a/contracts/zero-ex/contracts/test/TestRfqOriginRegistration.sol
+++ b/contracts/zero-ex/contracts/test/TestRfqOriginRegistration.sol
@@ -23,11 +23,7 @@ pragma experimental ABIEncoderV2;
 import "../src/features/interfaces/INativeOrdersFeature.sol";
 
 contract TestRfqOriginRegistration {
-    function registerAllowedRfqOrigins(
-        INativeOrdersFeature feature,
-        address[] memory origins,
-        bool allowed
-    ) external {
+    function registerAllowedRfqOrigins(INativeOrdersFeature feature, address[] memory origins, bool allowed) external {
         feature.registerAllowedRfqOrigins(origins, allowed);
     }
 }

--- a/contracts/zero-ex/contracts/test/TestStaking.sol
+++ b/contracts/zero-ex/contracts/test/TestStaking.sol
@@ -36,11 +36,7 @@ contract TestStaking {
         poolForMaker[msg.sender] = poolId;
     }
 
-    function payProtocolFee(
-        address makerAddress,
-        address payerAddress,
-        uint256 amount
-    ) external payable {
+    function payProtocolFee(address makerAddress, address payerAddress, uint256 amount) external payable {
         require(weth.transferFrom(payerAddress, address(this), amount));
         balanceForPool[poolForMaker[makerAddress]] += amount;
     }

--- a/contracts/zero-ex/contracts/test/TestTransformerBase.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerBase.sol
@@ -25,9 +25,7 @@ import "../src/transformers/IERC20Transformer.sol";
 import "../src/transformers/LibERC20Transformer.sol";
 
 contract TestTransformerBase is IERC20Transformer, Transformer {
-    function transform(
-        TransformContext calldata /* context */
-    ) external override returns (bytes4 success) {
+    function transform(TransformContext calldata /* context */) external override returns (bytes4 success) {
         return LibERC20Transformer.TRANSFORMER_SUCCESS;
     }
 }

--- a/contracts/zero-ex/contracts/test/TestTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerHost.sol
@@ -29,9 +29,10 @@ contract TestTransformerHost {
     using LibERC20Transformer for IERC20TokenV06;
     using LibRichErrorsV06 for bytes;
 
-    function rawExecuteTransform(IERC20Transformer transformer, IERC20Transformer.TransformContext calldata context)
-        external
-    {
+    function rawExecuteTransform(
+        IERC20Transformer transformer,
+        IERC20Transformer.TransformContext calldata context
+    ) external {
         (bool _success, bytes memory resultData) = address(transformer).delegatecall(
             abi.encodeWithSelector(transformer.transform.selector, context)
         );

--- a/contracts/zero-ex/contracts/test/TestWethTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestWethTransformerHost.sol
@@ -32,11 +32,7 @@ contract TestWethTransformerHost is TestTransformerHost {
         _weth = weth;
     }
 
-    function executeTransform(
-        uint256 wethAmount,
-        IERC20Transformer transformer,
-        bytes calldata data
-    ) external payable {
+    function executeTransform(uint256 wethAmount, IERC20Transformer transformer, bytes calldata data) external payable {
         if (wethAmount != 0) {
             _weth.deposit{value: wethAmount}();
         }

--- a/contracts/zero-ex/contracts/test/integration/TestCurve.sol
+++ b/contracts/zero-ex/contracts/test/integration/TestCurve.sol
@@ -45,11 +45,7 @@ contract TestCurve {
     IERC20TokenV06 public sellToken;
     TestMintableERC20Token public buyToken;
 
-    constructor(
-        IERC20TokenV06 sellToken_,
-        TestMintableERC20Token buyToken_,
-        uint256 buyAmount_
-    ) public payable {
+    constructor(IERC20TokenV06 sellToken_, TestMintableERC20Token buyToken_, uint256 buyAmount_) public payable {
         sellToken = sellToken_;
         buyToken = buyToken_;
         buyAmount = buyAmount_;

--- a/contracts/zero-ex/contracts/test/integration/TestUniswapV2Pool.sol
+++ b/contracts/zero-ex/contracts/test/integration/TestUniswapV2Pool.sol
@@ -27,12 +27,7 @@ contract TestUniswapV2Pool is IUniswapV2Pair {
         (token0, token1) = (params.token0, params.token1);
     }
 
-    function swap(
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address to,
-        bytes calldata /* data */
-    ) external override {
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata /* data */) external override {
         if (amount0Out > 0) {
             token0.transfer(to, amount0Out);
         }
@@ -41,26 +36,13 @@ contract TestUniswapV2Pool is IUniswapV2Pair {
         }
     }
 
-    function setReserves(
-        uint112 reserve0_,
-        uint112 reserve1_,
-        uint32 blockTimestampLast_
-    ) external {
+    function setReserves(uint112 reserve0_, uint112 reserve1_, uint32 blockTimestampLast_) external {
         reserve0 = reserve0_;
         reserve1 = reserve1_;
         blockTimestampLast = blockTimestampLast_;
     }
 
-    function getReserves()
-        external
-        view
-        override
-        returns (
-            uint112,
-            uint112,
-            uint32
-        )
-    {
+    function getReserves() external view override returns (uint112, uint112, uint32) {
         return (reserve0, reserve1, blockTimestampLast);
     }
 }

--- a/contracts/zero-ex/contracts/test/integration/TestUniswapV3Pool.sol
+++ b/contracts/zero-ex/contracts/test/integration/TestUniswapV3Pool.sol
@@ -15,11 +15,7 @@ interface IUniswapV3PoolDeployer {
 }
 
 interface IUniswapV3SwapCallback {
-    function uniswapV3SwapCallback(
-        int256 amount0Delta,
-        int256 amount1Delta,
-        bytes calldata data
-    ) external;
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external;
 }
 
 contract TestUniswapV3Pool is IUniswapV3Pool {

--- a/contracts/zero-ex/contracts/test/tokens/TestMintableERC1155Token.sol
+++ b/contracts/zero-ex/contracts/test/tokens/TestMintableERC1155Token.sol
@@ -108,11 +108,7 @@ contract TestMintableERC1155Token {
     // owner => (operator => approved)
     mapping(address => mapping(address => bool)) internal operatorApproval;
 
-    function mint(
-        address to,
-        uint256 id,
-        uint256 quantity
-    ) external {
+    function mint(address to, uint256 id, uint256 quantity) external {
         // Grant the items to the caller
         balances[id][to] = quantity.safeAdd(balances[id][to]);
 
@@ -152,13 +148,7 @@ contract TestMintableERC1155Token {
     /// @param id      ID of the token type
     /// @param value   Transfer amount
     /// @param data    Additional data with no specified format, sent in call to `_to`
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 id,
-        uint256 value,
-        bytes calldata data
-    ) external {
+    function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes calldata data) external {
         // sanity checks
         require(to != address(0x0), "CANNOT_TRANSFER_TO_ADDRESS_ZERO");
         require(from == msg.sender || operatorApproval[from][msg.sender] == true, "INSUFFICIENT_ALLOWANCE");
@@ -267,11 +257,10 @@ contract TestMintableERC1155Token {
     /// @param owners      The addresses of the token holders
     /// @param ids         ID of the Tokens
     /// @return balances_  The _owner's balance of the Token types requested
-    function balanceOfBatch(address[] calldata owners, uint256[] calldata ids)
-        external
-        view
-        returns (uint256[] memory balances_)
-    {
+    function balanceOfBatch(
+        address[] calldata owners,
+        uint256[] calldata ids
+    ) external view returns (uint256[] memory balances_) {
         // sanity check
         require(owners.length == ids.length, "OWNERS_AND_IDS_MUST_HAVE_SAME_LENGTH");
 

--- a/contracts/zero-ex/contracts/test/tokens/TestMintableERC20Token.sol
+++ b/contracts/zero-ex/contracts/test/tokens/TestMintableERC20Token.sol
@@ -35,11 +35,7 @@ contract TestMintableERC20Token {
         return true;
     }
 
-    function approveAs(
-        address owner,
-        address spender,
-        uint256 amount
-    ) external returns (bool) {
+    function approveAs(address owner, address spender, uint256 amount) external returns (bool) {
         allowance[owner][spender] = amount;
         return true;
     }
@@ -53,11 +49,7 @@ contract TestMintableERC20Token {
         balanceOf[owner] -= amount;
     }
 
-    function transferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) public virtual returns (bool) {
+    function transferFrom(address from, address to, uint256 amount) public virtual returns (bool) {
         if (from != msg.sender) {
             require(allowance[from][msg.sender] >= amount, "TestMintableERC20Token/INSUFFICIENT_ALLOWANCE");
             allowance[from][msg.sender] -= amount;

--- a/contracts/zero-ex/contracts/test/tokens/TestMintableERC721Token.sol
+++ b/contracts/zero-ex/contracts/test/tokens/TestMintableERC721Token.sol
@@ -123,12 +123,7 @@ contract TestMintableERC721Token {
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
     /// @param _data Additional data with no specified format, sent in call to `_to`
-    function safeTransferFrom(
-        address _from,
-        address _to,
-        uint256 _tokenId,
-        bytes calldata _data
-    ) external {
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes calldata _data) external {
         transferFrom(_from, _to, _tokenId);
 
         uint256 receiverCodeSize;
@@ -147,11 +142,7 @@ contract TestMintableERC721Token {
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    function safeTransferFrom(
-        address _from,
-        address _to,
-        uint256 _tokenId
-    ) external {
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external {
         transferFrom(_from, _to, _tokenId);
 
         uint256 receiverCodeSize;
@@ -209,11 +200,7 @@ contract TestMintableERC721Token {
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    function transferFrom(
-        address _from,
-        address _to,
-        uint256 _tokenId
-    ) public {
+    function transferFrom(address _from, address _to, uint256 _tokenId) public {
         require(_to != address(0), "ERC721_ZERO_TO_ADDRESS");
 
         address owner = ownerOf(_tokenId);

--- a/contracts/zero-ex/contracts/test/tokens/TestTokenSpenderERC20Token.sol
+++ b/contracts/zero-ex/contracts/test/tokens/TestTokenSpenderERC20Token.sol
@@ -39,11 +39,7 @@ contract TestTokenSpenderERC20Token is TestMintableERC20Token {
         _isGreedyRevert = isGreedy;
     }
 
-    function transferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) public override returns (bool) {
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
         emit TransferFromCalled(msg.sender, from, to, amount);
         if (amount == EMPTY_RETURN_AMOUNT) {
             assembly {
@@ -73,12 +69,7 @@ contract TestTokenSpenderERC20Token is TestMintableERC20Token {
         return true;
     }
 
-    function setBalanceAndAllowanceOf(
-        address owner,
-        uint256 balance,
-        address spender,
-        uint256 allowance_
-    ) external {
+    function setBalanceAndAllowanceOf(address owner, uint256 balance, address spender, uint256 allowance_) external {
         balanceOf[owner] = balance;
         allowance[owner][spender] = allowance_;
     }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "lerna": "^3.0.0-beta.25",
         "npm-run-all": "^4.1.2",
         "prettier": "2.7.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.24",
+        "prettier-plugin-solidity": "^1.0.0",
         "solhint": "^3.3.7",
         "solhint-plugin-prettier": "^0.0.5",
         "source-map-support": "^0.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3098,17 +3098,10 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
-"@solidity-parser/parser@^0.14.1":
+"@solidity-parser/parser@^0.14.1", "@solidity-parser/parser@^0.14.5":
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
   integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
-  dependencies:
-    antlr4ts "^0.5.0-alpha.4"
-
-"@solidity-parser/parser@^0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.3.tgz#0d627427b35a40d8521aaa933cc3df7d07bfa36f"
-  integrity sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
@@ -6784,10 +6777,10 @@ emittery@^0.4.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.4.1.tgz#abe9d3297389ba424ac87e53d1c701962ce7433d"
   integrity sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==
 
-emoji-regex@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.1.0.tgz#d50e383743c0f7a5945c47087295afc112e3cf66"
-  integrity sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==
+emoji-regex@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.2.1.tgz#a41c330d957191efd3d9dfe6e1e8e1e9ab048b3f"
+  integrity sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -12652,15 +12645,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-solidity@^1.0.0-beta.24:
-  version "1.0.0-beta.24"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.24.tgz#67573ca87098c14f7ccff3639ddd8a4cab2a87eb"
-  integrity sha512-6JlV5BBTWzmDSq4kZ9PTXc3eLOX7DF5HpbqmmaF+kloyUwOZbJ12hIYsUaZh2fVgZdV2t0vWcvY6qhILhlzgqg==
+prettier-plugin-solidity@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0.tgz#5b23f48cc9c28a1246c6dd89af117234b813f48b"
+  integrity sha512-gRJCeZ7imbWtNYN2SudjJoPmka5r6jcd2cSTV6FC3pVCtY6LFZbeQQjpKufUEp88hXBAAnkOTOh7TA5xwj9M3A==
   dependencies:
-    "@solidity-parser/parser" "^0.14.3"
-    emoji-regex "^10.1.0"
+    "@solidity-parser/parser" "^0.14.5"
+    emoji-regex "^10.2.1"
     escape-string-regexp "^4.0.0"
-    semver "^7.3.7"
+    semver "^7.3.8"
     solidity-comments-extractor "^0.0.7"
     string-width "^4.2.3"
 
@@ -13700,6 +13693,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.4.1:
   version "5.4.1"


### PR DESCRIPTION
`prettier-plugin-solidity` finally has its first stable version so here we upgrade that to v 1.0.0

This has started properly failing prettier CI checks for contracts which was oddly passing before, even though contracts weren't formatted.

https://app.circleci.com/pipelines/github/0xProject/protocol/4253/workflows/80fed792-b60a-4602-b876-467d46474df5/jobs/21575

Closes https://linear.app/0xproject/issue/GOV-33/upgrade-prettier-plugin-solidity-to-stable-v1