### PR TITLE
chore: removing Aave V2 and Aave V3 from Fantom

### DIFF
--- a/contracts/zero-ex/contracts/src/transformers/bridges/FantomBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/FantomBridgeAdapter.sol
@@ -22,8 +22,6 @@ pragma experimental ABIEncoderV2;
 
 import "./AbstractBridgeAdapter.sol";
 import "./BridgeProtocols.sol";
-import "./mixins/MixinAaveV3.sol";
-import "./mixins/MixinAaveV2.sol";
 import "./mixins/MixinBalancerV2.sol";
 import "./mixins/MixinBalancerV2Batch.sol";
 import "./mixins/MixinCurve.sol";
@@ -35,8 +33,6 @@ import "./mixins/MixinZeroExBridge.sol";
 
 contract FantomBridgeAdapter is
     AbstractBridgeAdapter(250, "Fantom"),
-    MixinAaveV3,
-    MixinAaveV2,
     MixinBalancerV2,
     MixinBalancerV2Batch,
     MixinCurve,
@@ -46,7 +42,7 @@ contract FantomBridgeAdapter is
     MixinWOOFi,
     MixinZeroExBridge
 {
-    constructor(IEtherTokenV06 weth) public MixinCurve(weth) MixinAaveV3(false) {}
+    constructor(IEtherTokenV06 weth) public MixinCurve(weth){}
 
     function _trade(
         BridgeOrder memory order,
@@ -86,11 +82,6 @@ contract FantomBridgeAdapter is
                 return (0, true);
             }
             boughtAmount = _tradeNerve(sellToken, sellAmount, order.bridgeData);
-        } else if (protocolId == BridgeProtocols.AAVEV2) {
-            if (dryRun) {
-                return (0, true);
-            }
-            boughtAmount = _tradeAaveV2(sellToken, buyToken, sellAmount, order.bridgeData);
         } else if (protocolId == BridgeProtocols.WOOFI) {
             if (dryRun) {
                 return (0, true);
@@ -101,11 +92,6 @@ contract FantomBridgeAdapter is
                 return (0, true);
             }
             boughtAmount = _tradeZeroExBridge(sellToken, buyToken, sellAmount, order.bridgeData);
-        } else if (protocolId == BridgeProtocols.AAVEV3) {
-            if (dryRun) {
-                return (0, true);
-            }
-            boughtAmount = _tradeAaveV3(sellToken, buyToken, sellAmount, order.bridgeData);
         }
 
         emit BridgeFill(order.source, sellToken, buyToken, sellAmount, boughtAmount);

--- a/contracts/zero-ex/contracts/src/transformers/bridges/FantomBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/FantomBridgeAdapter.sol
@@ -42,7 +42,7 @@ contract FantomBridgeAdapter is
     MixinWOOFi,
     MixinZeroExBridge
 {
-    constructor(IEtherTokenV06 weth) public MixinCurve(weth){}
+    constructor(IEtherTokenV06 weth) public MixinCurve(weth) {}
 
     function _trade(
         BridgeOrder memory order,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removing both Aave V2 and Aave V3 from Fantom's Bridge Adapter. Aave V2 is not supported on Fantom and Aave V3 lending activity is frozen on Fantom.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
