### PR TITLE
Update auto labeller and stale bot for issues and PRs

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,6 +1,2 @@
-python: ['python-packages']
-contracts: ['contracts']
-@0x/contract-addresses: ['packages/contract-addresses']
-@0x/order-utils: ['packages/order-utils']
-@0x/contract-artifacts: ['packages/contract-artifacts']
-@0x/contract-wrappers: ['packages/contract-wrappers']
+documentation: ['docs']
+liquidity integrations: ['contracts/zero-ex/contracts/src/transformers']

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,5 +15,5 @@ markComment: >
     for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-    This issue has been automatically closed because no activity occured in 7 days after being marked as stale. If it's still relevant - feel free to reopen. Thank you
+    This issue has been automatically closed because no activity occured in 30 days after being marked as stale. If it's still relevant - feel free to reopen. Thank you
     for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,19 +1,21 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
-# Issues with these labels will never be considered stale
-exemptLabels:
-    - pinned
-    - security
-# Label to use when marking an issue as stale
+# Label to use when marking an issue or PR as stale
 staleLabel: stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
+
+pulls:
+  daysUntilStale: 30
+  daysUntilClose: 14
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+issues:
+  daysUntilStale: 30
+  daysUntilClose: 14
+  markComment: >
     This issue has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: >
-    This issue has been automatically closed because no activity occured in 30 days after being marked as stale. If it's still relevant - feel free to reopen. Thank you
-    for your contributions.
+ exemptLabels:
+   - bug
+   - enhancement
+   - feature
+   - question


### PR DESCRIPTION
Updating [autolabeller](https://github.com/apps/probot-autolabeler) process in github to assign `documentation` and `liquidity integrations` labels to `/docs` and `contracts/zero-ex/contracts/src/transformers` changes.

Also switching the stale autolabeller to close after 14 days.

Closes https://linear.app/0xproject/issue/GOV-34/update-github-labels