### PR TITLE
Migrate meta tx tests [RFQ-793]

### DIFF
--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -281,7 +281,8 @@ contract MetaTransactionTest is BaseTest {
         // TODO: check event log for TestMetaTransactionsNativeOrdersFeatureEvents.FillLimitOrderCalled?
     }
 
-    function test_fillLimitOrder() public {
+    function test_fillLimitOrder() external {
+
         bytes memory callData = makeTestLimitOrder();
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);
 

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -213,7 +213,8 @@ contract MetaTransactionTest is BaseTest {
         );
     }
 
-    function mtxCall(IMetaTransactionsFeature.MetaTransactionData memory mtx) private returns (bytes memory) {
+    function _mtxCall(IMetaTransactionsFeature.MetaTransactionData memory mtx) private returns (bytes memory) {
+
         // Mint fee to signer and approve
         if (mtx.feeAmount > 0) {
             mintTo(address(mtx.feeToken), mtx.signer, mtx.feeAmount);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -262,7 +262,8 @@ contract MetaTransactionTest is BaseTest {
         assertEq(wethToken.balanceOf(address(this)), 1);
     }
 
-    function test_rfqOrder() public {
+    function test_rfqOrder() external {
+
         bytes memory callData = makeTestRfqOrder();
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);
 

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+
+  Copyright 2023 ZeroEx Intl.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+pragma solidity ^0.6.5;
+pragma experimental ABIEncoderV2;
+
+import "./utils/BaseTest.sol";
+import "forge-std/Test.sol";
+import "./utils/DeployZeroEx.sol";
+import "../contracts/src/features/MetaTransactionsFeature.sol";
+import "../contracts/src/features/interfaces/IMetaTransactionsFeature.sol";
+import "../contracts/test/TestMintTokenERC20Transformer.sol";
+import "../contracts/src/features/libs/LibSignature.sol";
+import "src/features/libs/LibNativeOrder.sol";
+import "../contracts/test/tokens/TestMintableERC20Token.sol";
+import "@0x/contracts-erc20/contracts/src/v06/IEtherTokenV06.sol";
+
+contract MetaTransactionTest is BaseTest {
+    DeployZeroEx.ZeroExDeployed zeroExDeployed;
+    address private constant ZERO_ADDRESS = 0x0000000000000000000000000000000000000000;
+    address private constant USER_ADDRESS = 0x6dc3a54FeAE57B65d185A7B159c5d3FA7fD7FD0F;
+    uint256 private constant USER_KEY = 0x1fc1630343b31e60b7a197a53149ca571ed9d9791e2833337bbd8110c30710ec;
+    IEtherTokenV06 private wethToken;
+    IERC20TokenV06 private usdcToken;
+    IERC20TokenV06 private zrxToken;
+    uint256 private constant oneEth = 1e18;
+    address private signerAddress;
+    uint256 private signerKey;
+    uint256 private transformerNonce;
+
+
+    function setUp() public {
+        (signerAddress, signerKey) = getSigner();
+        zeroExDeployed = new DeployZeroEx().deployZeroEx();
+        wethToken = zeroExDeployed.weth;
+        usdcToken = IERC20TokenV06(address(new TestMintableERC20Token()));
+        zrxToken = IERC20TokenV06(address(new TestMintableERC20Token()));
+
+        transformerNonce = zeroExDeployed.transformerDeployer.nonce();
+        vm.prank(zeroExDeployed.transformerDeployer.authorities(0));
+        zeroExDeployed.transformerDeployer.deploy(type(TestMintTokenERC20Transformer).creationCode);
+
+        vm.deal(address(this), 10e18);
+        vm.deal(USER_ADDRESS, 10e18);
+        vm.deal(signerAddress, 10e18);
+    }
+
+    function getSigner() public returns (address, uint) {
+        string memory mnemonic = "test test test test test test test test test test test junk";
+        uint256 privateKey = vm.deriveKey(mnemonic, 0);
+        vm.label(vm.addr(privateKey), "zeroEx/MarketMaker");
+        return (vm.addr(privateKey), privateKey);
+    }
+
+    function makeTestRfqOrder() private returns (bytes memory callData) {
+        LibNativeOrder.RfqOrder memory order = LibNativeOrder.RfqOrder({
+            makerToken: wethToken,
+            takerToken: usdcToken,
+            makerAmount: 1e18,
+            takerAmount: 1e18,
+            maker: signerAddress,
+            taker: ZERO_ADDRESS,
+            txOrigin: tx.origin,
+            pool: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            expiry: uint64(block.timestamp + 60),
+            salt: 123
+        });
+        mintTo(address(order.makerToken), order.maker, order.makerAmount);
+        vm.prank(order.maker);
+        order.makerToken.approve(address(zeroExDeployed.zeroEx), order.makerAmount);
+        mintTo(address(order.takerToken), USER_ADDRESS, order.takerAmount);
+        vm.prank(USER_ADDRESS);
+        order.takerToken.approve(address(zeroExDeployed.zeroEx), order.takerAmount);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, zeroExDeployed.features.nativeOrdersFeature.getRfqOrderHash(order));
+        LibSignature.Signature memory sig = LibSignature.Signature(LibSignature.SignatureType.EIP712, v, r, s);
+
+
+        return abi.encodeWithSelector(
+            INativeOrdersFeature.fillRfqOrder.selector, // ??
+            order,  // RFQOrder
+            sig,    // Order Signature
+            1e18   // Fill Amount
+        );
+    }
+
+    function mintTo(address token, address recipient, uint256 amount) private {
+        if (token == address(wethToken)) {
+            //vm.prank(recipient);
+            IEtherTokenV06(token).deposit{value: amount}();
+            WETH9V06(payable(token)).transfer(recipient, amount);
+        } else {
+            TestMintableERC20Token(token).mint(recipient, amount);
+        }
+    }
+
+    function getRandomMetaTransaction(bytes memory callData) private view returns (IMetaTransactionsFeature.MetaTransactionData memory) {   
+        IMetaTransactionsFeature.MetaTransactionData memory mtx = IMetaTransactionsFeature.MetaTransactionData({
+            signer: payable(USER_ADDRESS),
+            sender: address(this),
+            minGasPrice: 0,
+            maxGasPrice: 100000000000,
+            expirationTimeSeconds: block.timestamp + 60,
+            salt: 123,
+            callData: callData,
+            value: 0,
+            feeToken: wethToken,
+            feeAmount: 1
+        });
+        return mtx;
+    }
+
+    function transformERC20Call() private returns (bytes memory) {
+        ITransformERC20Feature.Transformation[] memory transformations = new ITransformERC20Feature.Transformation[](1);
+        transformations[0] = ITransformERC20Feature.Transformation(
+            uint32(transformerNonce),
+            abi.encode(address(usdcToken), address(zrxToken), 0, oneEth, 0)
+        );
+
+        mintTo(address(usdcToken), USER_ADDRESS, oneEth);
+        vm.prank(USER_ADDRESS);
+        usdcToken.approve(address(zeroExDeployed.zeroEx), oneEth);
+
+        return abi.encodeWithSelector(
+            zeroExDeployed.zeroEx.transformERC20.selector, // 0x415565b0
+            usdcToken,
+            zrxToken,
+            oneEth,
+            oneEth,
+            transformations
+        );
+    }
+
+    function mtxCall(IMetaTransactionsFeature.MetaTransactionData memory mtx) private returns (bytes memory) {
+        // Mint fee to signer and approve
+        if (mtx.feeAmount > 0) {
+            mintTo(address(mtx.feeToken), mtx.signer, mtx.feeAmount);
+            vm.prank(mtx.signer);
+            mtx.feeToken.approve(address(zeroExDeployed.zeroEx), oneEth);
+        }
+
+        bytes32 mtxHash = zeroExDeployed.features.metaTransactionsFeature.getMetaTransactionHash(mtx);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(USER_KEY, mtxHash);
+        LibSignature.Signature memory sig = LibSignature.Signature(LibSignature.SignatureType.EIP712, v, r, s);
+
+        return abi.encodeWithSelector(
+            zeroExDeployed.zeroEx.executeMetaTransaction.selector, // 0x3d61ed3e
+            mtx,
+            sig
+        );
+    }
+
+    function test_createHash() public {
+        bytes memory transformCallData = transformERC20Call();
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
+
+        //mtxData.signer = address(0);
+        bytes32 mtxHash = zeroExDeployed.features.metaTransactionsFeature.getMetaTransactionHash(mtxData);
+        assertTrue(mtxHash != bytes32(0));
+    }
+
+    function test_transformERC20() public {
+        bytes memory transformCallData = transformERC20Call();
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
+
+        bytes memory theCallData = mtxCall(mtxData);
+
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), oneEth);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0}(theCallData);
+        assertTrue(success);
+        assertEq(zrxToken.balanceOf(USER_ADDRESS), oneEth);
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), 0);
+        assertEq(wethToken.balanceOf(address(this)), 1);
+    }
+
+    function test_rfqOrder() public {
+        bytes memory callData = makeTestRfqOrder();
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);
+
+        bytes memory rfqCallData = mtxCall(mtxData);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0 }(rfqCallData);
+        
+        assertTrue(success);
+        assertEq(wethToken.balanceOf(signerAddress), 0);
+        assertEq(wethToken.balanceOf(USER_ADDRESS), 1e18);
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), 0);
+        assertEq(usdcToken.balanceOf(signerAddress), 1e18);
+        assertEq(wethToken.balanceOf(address(this)), 1);
+
+        // TODO: check event log for TestMetaTransactionsNativeOrdersFeatureEvents.FillLimitOrderCalled?
+    }
+
+    function test_fillLimitOrder() public {
+
+    }
+
+    function test_transformERC20WithAnySender() public {
+        bytes memory transformCallData = transformERC20Call();
+
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
+        mtxData.sender = ZERO_ADDRESS;
+
+        bytes memory theCallData = mtxCall(mtxData);
+
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), oneEth);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0}(theCallData);
+        assertTrue(success);
+        assertEq(zrxToken.balanceOf(USER_ADDRESS), oneEth);
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), 0);
+        assertEq(wethToken.balanceOf(address(this)), 1);
+    }
+
+    function test_transformERC20WithoutFee() public {
+        bytes memory transformCallData = transformERC20Call();
+
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
+        mtxData.feeAmount = 0;
+
+        bytes memory theCallData = mtxCall(mtxData);
+
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), oneEth);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0}(theCallData);
+        assertTrue(success);
+        assertEq(zrxToken.balanceOf(USER_ADDRESS), oneEth);
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), 0);
+        assertEq(wethToken.balanceOf(address(this)), 0); // no fee paid out
+    }
+
+    function test_transformERC20TranslatedCallFail() public {
+
+    }
+
+    function test_transformERC20UnsupportedFunction() public {
+
+    }
+
+    function test_transformERC20CantExecuteTwice() public {
+
+    }
+
+    function test_metaTxnFailsNotEnoughEth() public {
+        bytes memory callData = makeTestRfqOrder();
+
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);
+        mtxData.value = 1;
+
+        bytes memory theCallData = mtxCall(mtxData);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0}(theCallData);
+        assertFalse(success);
+    }
+/*
+    function test_metaTxnFailsGasPriceTooLow() public {
+        
+    }
+
+    function test_metaTxnFailsGasPriceTooHigh() public {
+        
+    }*/
+
+    function test_metaTxnFailsIfExpired() public {
+        bytes memory callData = makeTestRfqOrder();
+
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);
+        mtxData.expirationTimeSeconds = block.timestamp;
+
+        bytes memory theCallData = mtxCall(mtxData);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0}(theCallData);
+        assertFalse(success);
+    }
+
+    function test_metaTxnFailsIfWrongSender() public {
+        bytes memory transformCallData = transformERC20Call();
+        IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
+        mtxData.sender = USER_ADDRESS;
+
+        bytes memory theCallData = mtxCall(mtxData);
+
+        assertEq(usdcToken.balanceOf(USER_ADDRESS), oneEth);
+
+        (bool success, ) = address(zeroExDeployed.zeroEx).call{ value: 0}(theCallData);
+        assertFalse(success);
+    }
+
+    function test_metaTxnFailsWrongSignature() public {
+        
+    }
+
+    function test_metaTxnCantReenterExecuteMetaTransaction() public {
+        
+    }
+
+    function test_metaTxnCantReenterBatchExecuteMetaTransaction() public {
+        
+    }
+
+    function test_metaTxnCantReduceInitialEthBalance() public {
+        
+    }
+}

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -137,7 +137,8 @@ contract MetaTransactionTest is BaseTest {
         );
     }
 
-    function mintTo(address token, address recipient, uint256 amount) private {
+    function _mintTo(address token, address recipient, uint256 amount) private {
+
         if (token == address(wethToken)) {
             //vm.prank(recipient);
             IEtherTokenV06(token).deposit{value: amount}();

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -246,7 +246,8 @@ contract MetaTransactionTest is BaseTest {
         assertTrue(mtxHash != bytes32(0));
     }
 
-    function test_transformERC20() public {
+    function test_transformERC20() external {
+
         bytes memory transformCallData = transformERC20Call();
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
 

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -102,7 +102,8 @@ contract MetaTransactionTest is BaseTest {
         );
     }
 
-    function makeTestLimitOrder() private returns (bytes memory callData) {
+    function _makeTestLimitOrder() private returns (bytes memory callData) {
+
         LibNativeOrder.LimitOrder memory order = LibNativeOrder.LimitOrder({
             makerToken: wethToken,
             takerToken: usdcToken,

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -297,7 +297,8 @@ contract MetaTransactionTest is BaseTest {
         assertEq(usdcToken.balanceOf(signerAddress), 1e18);
     }
 
-    function test_transformERC20WithAnySender() public {
+    function test_transformERC20WithAnySender() external {
+
         bytes memory transformCallData = transformERC20Call();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -165,7 +165,8 @@ contract MetaTransactionTest is BaseTest {
         return mtx;
     }
 
-    function transformERC20Call() private returns (bytes memory) {
+    function _transformERC20Call() private returns (bytes memory) {
+
         ITransformERC20Feature.Transformation[] memory transformations = new ITransformERC20Feature.Transformation[](1);
         transformations[0] = ITransformERC20Feature.Transformation(
             uint32(transformerNonce),

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -362,7 +362,8 @@ contract MetaTransactionTest is BaseTest {
         assertFalse(success);
     }
 
-    function test_metaTxnFailsNotEnoughEth() public {
+    function test_metaTxnFailsNotEnoughEth() external {
+
         bytes memory callData = makeTestRfqOrder();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -194,7 +194,8 @@ contract MetaTransactionTest is BaseTest {
         );
     }
 
-    function badTokenTransformERC20Call() private returns (bytes memory) {
+    function _badTokenTransformERC20Call() private returns (bytes memory) {
+
         ITransformERC20Feature.Transformation[] memory transformations = new ITransformERC20Feature.Transformation[](1);
         transformations[0] = ITransformERC20Feature.Transformation(
             uint32(transformerNonce),

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -186,7 +186,8 @@ contract MetaTransactionTest is BaseTest {
         );
     }
 
-    function badSelectorTransformERC20Call() private returns (bytes memory) {
+    function _badSelectorTransformERC20Call() private returns (bytes memory) {
+
         return abi.encodeWithSelector(
             ITransformERC20Feature.createTransformWallet.selector
         );

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -333,7 +333,8 @@ contract MetaTransactionTest is BaseTest {
         assertEq(wethToken.balanceOf(address(this)), 0); // no fee paid out
     }
 
-    function test_transformERC20TranslatedCallFail() public {
+    function test_transformERC20TranslatedCallFail() external {
+
         bytes memory transformCallData = badTokenTransformERC20Call();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -315,7 +315,8 @@ contract MetaTransactionTest is BaseTest {
         assertEq(wethToken.balanceOf(address(this)), 1);
     }
 
-    function test_transformERC20WithoutFee() public {
+    function test_transformERC20WithoutFee() external {
+
         bytes memory transformCallData = transformERC20Call();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -346,7 +346,8 @@ contract MetaTransactionTest is BaseTest {
         assertFalse(success);
     }
 
-    function test_transformERC20CantExecuteTwice() public {
+    function test_transformERC20CantExecuteTwice() external {
+
         bytes memory callData = makeTestRfqOrder();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -345,7 +345,8 @@ contract MetaTransactionTest is BaseTest {
         assertFalse(success);
     }
 
-    function test_transformERC20UnsupportedFunction() public {
+    function test_transformERC20UnsupportedFunction() external {
+
         bytes memory transformCallData = badSelectorTransformERC20Call();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -236,7 +236,8 @@ contract MetaTransactionTest is BaseTest {
         );
     }
 
-    function test_createHash() public {
+    function test_createHash() external {
+
         bytes memory transformCallData = transformERC20Call();
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
 

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -61,7 +61,8 @@ contract MetaTransactionTest is BaseTest {
         vm.deal(signerAddress, 10e18);
     }
 
-    function getSigner() public returns (address, uint) {
+    function _getSigner() private returns (address, uint) {
+
         string memory mnemonic = "test test test test test test test test test test test junk";
         uint256 privateKey = vm.deriveKey(mnemonic, 0);
         vm.label(vm.addr(privateKey), "zeroEx/MarketMaker");

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -385,7 +385,8 @@ contract MetaTransactionTest is BaseTest {
     }
 *******/
 
-    function test_metaTxnFailsIfExpired() public {
+    function test_metaTxnFailsIfExpired() external {
+
         bytes memory callData = makeTestRfqOrder();
 
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(callData);

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -69,7 +69,8 @@ contract MetaTransactionTest is BaseTest {
         return (vm.addr(privateKey), privateKey);
     }
 
-    function makeTestRfqOrder() private returns (bytes memory callData) {
+    function _makeTestRfqOrder() private returns (bytes memory callData) {
+
         LibNativeOrder.RfqOrder memory order = LibNativeOrder.RfqOrder({
             makerToken: wethToken,
             takerToken: usdcToken,

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -395,7 +395,8 @@ contract MetaTransactionTest is BaseTest {
         assertFalse(success);
     }
 
-    function test_metaTxnFailsIfWrongSender() public {
+    function test_metaTxnFailsIfWrongSender() external {
+
         bytes memory transformCallData = transformERC20Call();
         IMetaTransactionsFeature.MetaTransactionData memory mtxData = getRandomMetaTransaction(transformCallData);
         mtxData.sender = USER_ADDRESS;

--- a/contracts/zero-ex/tests/MetaTransactionTest.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionTest.t.sol
@@ -148,7 +148,8 @@ contract MetaTransactionTest is BaseTest {
         }
     }
 
-    function getRandomMetaTransaction(bytes memory callData) private view returns (IMetaTransactionsFeature.MetaTransactionData memory) {   
+    function _getMetaTransaction(bytes memory callData) private view returns (IMetaTransactionsFeature.MetaTransactionData memory) {   
+
         IMetaTransactionsFeature.MetaTransactionData memory mtx = IMetaTransactionsFeature.MetaTransactionData({
             signer: payable(USER_ADDRESS),
             sender: address(this),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
As protocol now can run forge tests, we want to port various tests from typescript to forge. Here we are porting over the metatransaction tests from meta_transaction_tests.ts. Not every test was ported, just the ones that test the most important functionality.

This is a WIP, so I'm putting it up as a draft PR.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->
Run forge test.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* New forge tests.

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
