### PR TITLE
chore: Skip chain id validation in `AbstractBridgeAdapter` on testnets

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -4,6 +4,9 @@
         "changes": [
             {
                 "note": "Add KyberElastic mixin for Ethereum, Polygon, Arbitrum, Avalanche"
+            },
+            {
+                "note": "Skip chain id validation in AbstractBridgeAdapter on testnets"
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/transformers/bridges/AbstractBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/AbstractBridgeAdapter.sol
@@ -23,8 +23,14 @@ abstract contract AbstractBridgeAdapter is IBridgeAdapter {
         assembly {
             chainId := chainid()
         }
-        // Allow testing on Ganache
-        if (chainId != expectedChainId && chainId != 1337) {
+        // Skip chain id validation on Ganache (1337), Anvil (31337), Goerli (5), Mumbai (80001), Base Goerli (84531)
+        bool skipValidation = (chainId == 1337 ||
+            chainId == 31337 ||
+            chainId == 5 ||
+            chainId == 80001 ||
+            chainId == 84531);
+
+        if (chainId != expectedChainId && !skipValidation) {
             revert(string(abi.encodePacked(expectedChainName, "BridgeAdapter.constructor: wrong chain ID")));
         }
     }


### PR DESCRIPTION
## Description

Skip chain id validation in `AbstractBridgeAdapter` on testnets so that a chain specific bridge adapter can be re-used on testnets (e.g. deploying `EthereumBridgeAdapter` on Goerli). 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Add tests to cover changes as needed - n/a
-   [x] Update documentation as needed. - n/a
-   [x] Add new entries to the relevant CHANGELOG.jsons. 
