### PR TITLE
Test votes migration for adding a new vote weight mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ contracts/governance/out
 packages/*/docs/README.md
 
 .DS_Store
+*~
+\#*\#
+.\#*
 
 # the snapshot that gets built for migrations sure does have a ton of files
 packages/migrations/0x_ganache_snapshot*

--- a/contracts/governance/src/ZeroExVotes.sol
+++ b/contracts/governance/src/ZeroExVotes.sol
@@ -146,7 +146,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
                     uint256 newWeight,
                     uint256 oldQuadraticWeight,
                     uint256 newQuadraticWeight
-                ) = _writeCheckpoint(_checkpoints[src], _subtract, srcBalance, amount);
+                ) = _writeCheckpoint(_checkpoints[src], _subtract, srcBalance, srcBalanceLastUpdated, amount);
 
                 emit DelegateVotesChanged(src, oldWeight, newWeight);
                 emit DelegateQuadraticVotesChanged(src, oldQuadraticWeight, newQuadraticWeight);
@@ -158,7 +158,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
                     uint256 newWeight,
                     uint256 oldQuadraticWeight,
                     uint256 newQuadraticWeight
-                ) = _writeCheckpoint(_checkpoints[dst], _add, dstBalance, amount);
+                ) = _writeCheckpoint(_checkpoints[dst], _add, dstBalance, dstBalanceLastUpdated, amount);
 
                 emit DelegateVotesChanged(dst, oldWeight, newWeight);
                 emit DelegateQuadraticVotesChanged(dst, oldQuadraticWeight, newQuadraticWeight);
@@ -178,6 +178,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
             _totalSupplyCheckpoints,
             _add,
             accountBalance,
+            0,
             amount
         );
 
@@ -196,6 +197,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
             _totalSupplyCheckpoints,
             _subtract,
             accountBalance,
+            0,
             amount
         );
 
@@ -258,8 +260,13 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
         Checkpoint[] storage ckpts,
         function(uint256, uint256) view returns (uint256) op,
         uint256 userBalance,
+        uint96 balanceLastUpdated,
         uint256 delta
-    ) internal virtual returns (uint256 oldWeight, uint256 newWeight, uint256 oldQuadraticWeight, uint256 newQuadraticWeight) {
+    )
+        internal
+        virtual
+        returns (uint256 oldWeight, uint256 newWeight, uint256 oldQuadraticWeight, uint256 newQuadraticWeight)
+    {
         uint256 pos = ckpts.length;
 
         Checkpoint memory oldCkpt = pos == 0 ? Checkpoint(0, 0, 0) : _unsafeAccess(ckpts, pos - 1);

--- a/contracts/governance/src/ZeroExVotes.sol
+++ b/contracts/governance/src/ZeroExVotes.sol
@@ -31,7 +31,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
     address public immutable token;
     uint256 public immutable quadraticThreshold;
 
-    mapping(address => Checkpoint[]) private _checkpoints;
+    mapping(address => Checkpoint[]) internal _checkpoints;
     Checkpoint[] private _totalSupplyCheckpoints;
 
     constructor(address _token, uint256 _quadraticThreshold) {
@@ -48,7 +48,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
         _;
     }
 
-    function initialize() public onlyProxy initializer {
+    function initialize() public virtual onlyProxy initializer {
         __Ownable_init();
         __UUPSUpgradeable_init();
     }
@@ -211,7 +211,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
     function _checkpointsLookup(
         Checkpoint[] storage ckpts,
         uint256 blockNumber
-    ) private view returns (Checkpoint memory) {
+    ) internal view returns (Checkpoint memory) {
         // We run a binary search to look for the earliest checkpoint taken after `blockNumber`.
         //
         // Initially we check if the block is recent to narrow the search range.
@@ -259,7 +259,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
         function(uint256, uint256) view returns (uint256) op,
         uint256 userBalance,
         uint256 delta
-    ) private returns (uint256 oldWeight, uint256 newWeight, uint256 oldQuadraticWeight, uint256 newQuadraticWeight) {
+    ) internal virtual returns (uint256 oldWeight, uint256 newWeight, uint256 oldQuadraticWeight, uint256 newQuadraticWeight) {
         uint256 pos = ckpts.length;
 
         Checkpoint memory oldCkpt = pos == 0 ? Checkpoint(0, 0, 0) : _unsafeAccess(ckpts, pos - 1);
@@ -313,7 +313,7 @@ contract ZeroExVotes is IZeroExVotes, Initializable, OwnableUpgradeable, UUPSUpg
      * Implementation from openzeppelin/token/ERC20/extensions/ERC20Votes.sol
      * https://github.com/ethereum/solidity/issues/9117
      */
-    function _unsafeAccess(Checkpoint[] storage ckpts, uint256 pos) private pure returns (Checkpoint storage result) {
+    function _unsafeAccess(Checkpoint[] storage ckpts, uint256 pos) internal pure returns (Checkpoint storage result) {
         assembly ("memory-safe") {
             mstore(0, ckpts.slot)
             result.slot := add(keccak256(0, 0x20), pos)

--- a/contracts/governance/test/CubeRoot.sol
+++ b/contracts/governance/test/CubeRoot.sol
@@ -1,32 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-// Originaly from https://github.com/Vectorized/solady/blob/main/src/utils/FixedPointMathLib.sol
 library CubeRoot {
     /// @dev Returns the cube root of `x`.
-    /// Credit to bout3fiddy and pcaversaccio under AGPLv3 license:
-    /// https://github.com/pcaversaccio/snekmate/blob/main/src/utils/Math.vy
-    function cbrt(uint256 x) internal pure returns (uint256 z) {
-        /// @solidity memory-safe-assembly
-        assembly {
-            let r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
-            r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
-            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
-            r := or(r, shl(4, lt(0xffff, shr(r, x))))
-            r := or(r, shl(3, lt(0xff, shr(r, x))))
-
-            z := shl(add(div(r, 3), lt(0xf, shr(r, x))), 0xff)
-            z := div(z, byte(mod(r, 3), shl(232, 0x7f624b)))
-
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
-
-            z := sub(z, lt(div(x, mul(z, z)), z))
+    /// Credit to pleasemarkdarkly under MIT license
+    // Originaly from https://github.com/pleasemarkdarkly/fei-protocol-core-hh/blob/main/contracts/utils/Roots.sol
+    function cbrt(uint y) internal pure returns (uint z) {
+        // Newton's method https://en.wikipedia.org/wiki/Cube_root#Numerical_methods
+        if (y > 7) {
+            z = y;
+            uint x = y / 3 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / (x * x) + (2 * x)) / 3;
+            }
+        } else if (y != 0) {
+            z = 1;
         }
     }
 }

--- a/contracts/governance/test/CubeRoot.sol
+++ b/contracts/governance/test/CubeRoot.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+// Originaly from https://github.com/Vectorized/solady/blob/main/src/utils/FixedPointMathLib.sol
+library CubeRoot {
+    /// @dev Returns the cube root of `x`.
+    /// Credit to bout3fiddy and pcaversaccio under AGPLv3 license:
+    /// https://github.com/pcaversaccio/snekmate/blob/main/src/utils/Math.vy
+    function cbrt(uint256 x) internal pure returns (uint256 z) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
+            r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            r := or(r, shl(3, lt(0xff, shr(r, x))))
+
+            z := shl(add(div(r, 3), lt(0xf, shr(r, x))), 0xff)
+            z := div(z, byte(mod(r, 3), shl(232, 0x7f624b)))
+
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+
+            z := sub(z, lt(div(x, mul(z, z)), z))
+        }
+    }
+}

--- a/contracts/governance/test/ZeroExVotesMigration.sol
+++ b/contracts/governance/test/ZeroExVotesMigration.sol
@@ -138,6 +138,7 @@ contract ZeroExVotesMigration is ZeroExVotes {
         Checkpoint[] storage ckpts,
         function(uint256, uint256) view returns (uint256) op,
         uint256 userBalance,
+        uint96 balanceLastUpdated,
         uint256 delta
     )
         internal
@@ -163,9 +164,10 @@ contract ZeroExVotesMigration is ZeroExVotes {
                 ? userBalance
                 : quadraticThreshold + Math.sqrt((userBalance - quadraticThreshold) * 1e18);
             oldCkpt.quadraticVotes -= SafeCast.toUint96(oldQuadraticVotingPower);
-        }
-        if (oldCkpt.fromBlock > migrationBlock) {
-            oldCkpt.migratedVotes -= SafeCast.toUint32(CubeRoot.cbrt(userBalance)); // underflow
+
+            if (oldCkpt.fromBlock > migrationBlock && balanceLastUpdated > migrationBlock) {
+                oldCkpt.migratedVotes -= SafeCast.toUint32(CubeRoot.cbrt(userBalance));
+            }
         }
 
         // if wallet > threshold, calculate quadratic power over the treshold only, below threshold is linear

--- a/contracts/governance/test/ZeroExVotesMigration.sol
+++ b/contracts/governance/test/ZeroExVotesMigration.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+
+  Copyright 2023 ZeroEx Intl.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+pragma solidity ^0.8.19;
+
+import {ZeroExVotes} from "../src/ZeroExVotes.sol";
+import {SafeCast} from "@openzeppelin/utils/math/SafeCast.sol";
+import {Math} from "@openzeppelin/utils/math/Math.sol";
+import {CubeRoot} from "./CubeRoot.sol";
+
+contract ZeroExVotesMigration is ZeroExVotes {
+    uint32 public migrationBlock;
+
+    function initialize(address, uint256) public virtual override {
+        revert();
+    }
+
+    function initialize() public virtual onlyProxy reinitializer(2) {
+        migrationBlock = uint32(block.number);
+    }
+
+    struct CheckpointMigration {
+        uint32 fromBlock;
+        uint96 votes;
+        uint96 quadraticVotes;
+        uint32 migratedVotes;
+    }
+
+    function _toMigration(Checkpoint storage ckpt) internal pure returns (CheckpointMigration storage result) {
+        assembly {
+            result.slot := ckpt.slot
+        }
+    }
+
+    function _toMigration(Checkpoint[] storage ckpt) internal pure returns (CheckpointMigration[] storage result) {
+        assembly {
+            result.slot := ckpt.slot
+        }
+    }
+
+    function getMigratedVotes(address account) public view returns (uint256) {
+        uint256 pos = _checkpoints[account].length;
+        if (pos == 0) {
+            return 0;
+        }
+        Checkpoint storage ckpt = _unsafeAccess(_checkpoints[account], pos - 1);
+        if (ckpt.fromBlock <= migrationBlock) {
+            return 0;
+        }
+        return _toMigration(ckpt).migratedVotes;
+    }
+
+    function getPastMigratedVotes(address account, uint256 blockNumber) public view returns (uint256) {
+        require(blockNumber < block.number, "ZeroExVotesMigration: block not yet mined");
+        if (blockNumber <= migrationBlock) {
+            return 0;
+        }
+
+        (bool success, Checkpoint storage checkpoint) = _checkpointsLookup(_checkpoints[account], blockNumber);
+        if (!success) {
+            return 0;
+        }
+        if (checkpoint.fromBlock <= migrationBlock) {
+            return 0;
+        }
+        return _toMigration(checkpoint).migratedVotes;
+    }
+
+    // TODO: we're not handling totalSupply
+
+    // TODO: need to return the migrated weight
+    function _writeCheckpoint(
+        Checkpoint[] storage ckpts,
+        function(uint256, uint256) view returns (uint256) op,
+        uint256 userBalance,
+        uint256 delta
+    )
+        internal
+        virtual
+        override
+        returns (uint256 oldWeight, uint256 newWeight, uint256 oldQuadraticWeight, uint256 newQuadraticWeight)
+    {
+        uint256 pos = ckpts.length;
+
+        CheckpointMigration memory oldCkpt = pos == 0
+            ? CheckpointMigration(0, 0, 0, 0)
+            : _toMigration(_unsafeAccess(ckpts, pos - 1));
+
+        oldWeight = oldCkpt.votes;
+        newWeight = op(oldWeight, delta);
+
+        oldQuadraticWeight = oldCkpt.quadraticVotes;
+
+        // Remove the entire sqrt userBalance from quadratic voting power.
+        // Note that `userBalance` is value _after_ transfer.
+        if (pos > 0) {
+            uint256 oldQuadraticVotingPower = userBalance <= quadraticThreshold
+                ? userBalance
+                : quadraticThreshold + Math.sqrt((userBalance - quadraticThreshold) * 1e18);
+            oldCkpt.quadraticVotes -= SafeCast.toUint96(oldQuadraticVotingPower);
+        }
+        if (oldCkpt.fromBlock > migrationBlock) {
+            oldCkpt.migratedVotes -= SafeCast.toUint32(CubeRoot.cbrt(userBalance));
+        }
+
+        // if wallet > threshold, calculate quadratic power over the treshold only, below threshold is linear
+        uint256 newBalance = op(userBalance, delta);
+        uint256 newQuadraticBalance = newBalance <= quadraticThreshold
+            ? newBalance
+            : quadraticThreshold + Math.sqrt((newBalance - quadraticThreshold) * 1e18);
+        newQuadraticWeight = oldCkpt.quadraticVotes + newQuadraticBalance;
+        uint256 newMigratedWeight = oldCkpt.migratedVotes + CubeRoot.cbrt(newBalance);
+
+        if (pos > 0 && oldCkpt.fromBlock == block.number) {
+            CheckpointMigration storage chpt = _toMigration(_unsafeAccess(ckpts, pos - 1));
+            chpt.votes = SafeCast.toUint96(newWeight);
+            chpt.quadraticVotes = SafeCast.toUint96(newQuadraticWeight);
+            chpt.migratedVotes = SafeCast.toUint32(newMigratedWeight);
+        } else {
+            _toMigration(ckpts).push(
+                CheckpointMigration({
+                    fromBlock: SafeCast.toUint32(block.number),
+                    votes: SafeCast.toUint96(newWeight),
+                    quadraticVotes: SafeCast.toUint96(newQuadraticWeight),
+                    migratedVotes: SafeCast.toUint32(newMigratedWeight)
+                })
+            );
+        }
+    }
+}

--- a/contracts/governance/test/ZeroExVotesMigration.sol
+++ b/contracts/governance/test/ZeroExVotesMigration.sol
@@ -115,7 +115,7 @@ contract ZeroExVotesMigration is ZeroExVotes {
             oldCkpt.quadraticVotes -= SafeCast.toUint96(oldQuadraticVotingPower);
         }
         if (oldCkpt.fromBlock > migrationBlock) {
-            oldCkpt.migratedVotes -= SafeCast.toUint32(CubeRoot.cbrt(userBalance));
+            oldCkpt.migratedVotes -= SafeCast.toUint32(CubeRoot.cbrt(userBalance)); // underflow
         }
 
         // if wallet > threshold, calculate quadratic power over the treshold only, below threshold is linear

--- a/contracts/governance/test/ZeroExVotesTest.t.sol
+++ b/contracts/governance/test/ZeroExVotesTest.t.sol
@@ -64,7 +64,7 @@ contract ZeroExVotesTest is BaseTest {
 
         vm.roll(block.number + 1);
 
-        ZeroExVotesMigration newImpl = new ZeroExVotesMigration();
+        ZeroExVotesMigration newImpl = new ZeroExVotesMigration(address(token));
         assertFalse(
             address(
                 uint160(

--- a/contracts/governance/test/ZeroExVotesTest.t.sol
+++ b/contracts/governance/test/ZeroExVotesTest.t.sol
@@ -62,6 +62,9 @@ contract ZeroExVotesTest is BaseTest {
         wToken.delegate(account3);
         vm.stopPrank();
 
+        assertEq(votes.getVotes(account3), 300e18);
+        assertEq(votes.getQuadraticVotes(account3), 300e18);
+
         vm.roll(block.number + 1);
 
         ZeroExVotesMigration newImpl = new ZeroExVotesMigration(address(wToken), quadraticThreshold);
@@ -83,12 +86,25 @@ contract ZeroExVotesTest is BaseTest {
             address(newImpl)
         );
 
+        ZeroExVotesMigration upgradedVotes = ZeroExVotesMigration(address(votes));
+
+        assertEq(upgradedVotes.getVotes(account3), 300e18);
+        assertEq(upgradedVotes.getQuadraticVotes(account3), 300e18);
+
         vm.roll(block.number + 1);
 
         vm.prank(account2);
         wToken.transfer(address(this), 50e18);
+
+        assertEq(upgradedVotes.getVotes(account3), 250e18);
+        assertEq(upgradedVotes.getQuadraticVotes(account3), 250e18);
+        assertEq(upgradedVotes.getMigratedVotes(account3), CubeRoot.cbrt(50e18));
+
         vm.prank(account3);
         wToken.transfer(address(this), 100e18);
+        assertEq(upgradedVotes.getVotes(account3), 150e18);
+        assertEq(upgradedVotes.getQuadraticVotes(account3), 150e18);
+        assertEq(upgradedVotes.getMigratedVotes(account3), CubeRoot.cbrt(50e18) + CubeRoot.cbrt(100e18));
     }
 
     function testShouldNotBeAbleToStopBurn() public {

--- a/contracts/governance/test/ZeroExVotesTest.t.sol
+++ b/contracts/governance/test/ZeroExVotesTest.t.sol
@@ -18,10 +18,11 @@
 */
 pragma solidity ^0.8.19;
 
+import "@openzeppelin/token/ERC20/ERC20.sol";
 import "./BaseTest.t.sol";
 import "./ZeroExVotesMalicious.sol";
+import "./ZeroExVotesMigration.sol";
 import "../src/ZRXWrappedToken.sol";
-import "@openzeppelin/token/ERC20/ERC20.sol";
 
 contract ZeroExVotesTest is BaseTest {
     IERC20 private token;
@@ -44,6 +45,50 @@ contract ZeroExVotesTest is BaseTest {
     function testShouldNotBeAbleToReinitialise() public {
         vm.expectRevert("Initializable: contract is already initialized");
         votes.initialize();
+    }
+
+    function testShouldBeAbleToMigrate() public {
+        vm.roll(block.number + 1);
+
+        vm.startPrank(account2);
+        token.approve(address(wToken), 100e18);
+        wToken.depositFor(account2, 100e18);
+        wToken.delegate(account3);
+        vm.stopPrank();
+
+        vm.startPrank(account3);
+        token.approve(address(wToken), 200e18);
+        wToken.depositFor(account3, 200e18);
+        wToken.delegate(account3);
+        vm.stopPrank();
+
+        vm.roll(block.number + 1);
+
+        ZeroExVotesMigration newImpl = new ZeroExVotesMigration();
+        assertFalse(
+            address(
+                uint160(
+                    uint256(vm.load(address(votes), 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc))
+                )
+            ) == address(newImpl)
+        );
+        vm.prank(account1);
+        votes.upgradeToAndCall(address(newImpl), abi.encodeWithSignature("initialize()"));
+        assertEq(
+            address(
+                uint160(
+                    uint256(vm.load(address(votes), 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc))
+                )
+            ),
+            address(newImpl)
+        );
+
+        vm.roll(block.number + 1);
+
+        vm.prank(account2);
+        wToken.transfer(address(this), 50e18);
+        vm.prank(account3);
+        wToken.transfer(address(this), 100e18);
     }
 
     function testShouldNotBeAbleToStopBurn() public {

--- a/contracts/governance/test/ZeroExVotesTest.t.sol
+++ b/contracts/governance/test/ZeroExVotesTest.t.sol
@@ -64,7 +64,7 @@ contract ZeroExVotesTest is BaseTest {
 
         vm.roll(block.number + 1);
 
-        ZeroExVotesMigration newImpl = new ZeroExVotesMigration(address(token), quadraticThreshold);
+        ZeroExVotesMigration newImpl = new ZeroExVotesMigration(address(wToken), quadraticThreshold);
         assertFalse(
             address(
                 uint160(

--- a/contracts/governance/test/ZeroExVotesTest.t.sol
+++ b/contracts/governance/test/ZeroExVotesTest.t.sol
@@ -64,7 +64,7 @@ contract ZeroExVotesTest is BaseTest {
 
         vm.roll(block.number + 1);
 
-        ZeroExVotesMigration newImpl = new ZeroExVotesMigration(address(token));
+        ZeroExVotesMigration newImpl = new ZeroExVotesMigration(address(token), quadraticThreshold);
         assertFalse(
             address(
                 uint160(


### PR DESCRIPTION
Add a migration test for the voting logic. We simulate upgrading this to add a cube root vote weight mechanism. This utilizes of the currently unused `DelegateInfo.balanceLastUpdated` property which is passed to the voting contract by the wrapped token.