### PR TITLE
feat: removing L2 Encoding from AaveV3 MixIn [LIT-901]

### DIFF
--- a/contracts/zero-ex/contracts/src/transformers/bridges/ArbitrumBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/ArbitrumBridgeAdapter.sol
@@ -47,7 +47,7 @@ contract ArbitrumBridgeAdapter is
     MixinWOOFi,
     MixinZeroExBridge
 {
-    constructor(IEtherToken weth) public MixinCurve(weth) MixinAaveV3(true) {}
+    constructor(IEtherToken weth) public MixinCurve(weth) {}
 
     function _trade(
         BridgeOrder memory order,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/AvalancheBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/AvalancheBridgeAdapter.sol
@@ -45,7 +45,7 @@ contract AvalancheBridgeAdapter is
     MixinWOOFi,
     MixinZeroExBridge
 {
-    constructor(IEtherToken weth) public MixinCurve(weth) MixinAaveV3(false) {}
+    constructor(IEtherToken weth) public MixinCurve(weth) {}
 
     function _trade(
         BridgeOrder memory order,

--- a/contracts/zero-ex/contracts/src/transformers/bridges/OptimismBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/OptimismBridgeAdapter.sol
@@ -41,7 +41,7 @@ contract OptimismBridgeAdapter is
     MixinWOOFi,
     MixinZeroExBridge
 {
-    constructor(IEtherToken weth) public MixinCurve(weth) MixinAaveV3(true) {}
+    constructor(IEtherToken weth) public MixinCurve(weth) {}
 
     /* solhint-disable function-max-lines */
     function _trade(

--- a/contracts/zero-ex/contracts/src/transformers/bridges/PolygonBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/PolygonBridgeAdapter.sol
@@ -53,7 +53,7 @@ contract PolygonBridgeAdapter is
     MixinWOOFi,
     MixinZeroExBridge
 {
-    constructor(IEtherToken weth) public MixinCurve(weth) MixinAaveV3(false) {}
+    constructor(IEtherToken weth) public MixinCurve(weth) {}
 
     function _trade(
         BridgeOrder memory order,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removing the L2 Encoding for Aave V3 MixIn. The L2 encoding makes settlement more brittle and is causing some high revert rates specifically for MultiHop tokens involving Aave V3 tokens. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
