### PR TITLE
fix: remove vm.stopPrank if vm.startPrank not present

### DIFF
--- a/contracts/erc20/test/WETH9V06Test.t.sol
+++ b/contracts/erc20/test/WETH9V06Test.t.sol
@@ -39,7 +39,6 @@ contract WETH9V06Test is Test {
     function testShouldConvertDepositedETHToWrappedETH() public {
         vm.prank(user);
         etherToken.deposit{value: 1e20}();
-        vm.stopPrank();
 
         assertEq(etherToken.balanceOf(user), 1e20);
         assertEq(address(etherToken).balance, 1e20);
@@ -58,7 +57,6 @@ contract WETH9V06Test is Test {
         etherToken.deposit{value: 1e20}();
         vm.prank(user);
         etherToken.withdraw(100);
-        vm.stopPrank();
 
         assertEq(etherToken.balanceOf(user), 1e20 - 100);
         assertEq(address(etherToken).balance, 1e20 - 100);
@@ -68,7 +66,6 @@ contract WETH9V06Test is Test {
     function testShouldConvertSentETHToWrappedETH() public {
         vm.prank(user);
         address(etherToken).call{value: 1e20}(new bytes(0));
-        vm.stopPrank();
 
         assertEq(etherToken.balanceOf(user), 1e20);
         assertEq(address(etherToken).balance, 1e20);

--- a/contracts/erc20/test/ZRXTokenTest.t.sol
+++ b/contracts/erc20/test/ZRXTokenTest.t.sol
@@ -34,7 +34,6 @@ contract ZRXTokenTest is Test {
         assembly {
             _address := create(0, add(_bytecode, 0x20), mload(_bytecode))
         }
-        vm.stopPrank();
         zrxToken = IERC20Token(address(_address));
     }
 
@@ -73,7 +72,6 @@ contract ZRXTokenTest is Test {
     function testShouldReturnFalseIfSenderHasInsufficientBalance() public {
         vm.prank(owner);
         zrxToken.approve(user, totalSupply + 1);
-        vm.stopPrank();
 
         bool success = zrxToken.transferFrom(owner, user, totalSupply + 1);
         assertEq(success, false);
@@ -82,7 +80,6 @@ contract ZRXTokenTest is Test {
     function testShouldReturnFalseIfRecipientHasInsufficientAllowance() public {
         vm.prank(owner);
         zrxToken.approve(user, totalSupply - 1);
-        vm.stopPrank();
 
         bool success = zrxToken.transferFrom(owner, user, totalSupply);
         assertEq(success, false);
@@ -97,7 +94,6 @@ contract ZRXTokenTest is Test {
     function testShouldNotModifySenderAllowanceIfSetToUINT256Max() public {
         vm.prank(owner);
         zrxToken.approve(user, type(uint256).max);
-        vm.stopPrank();
 
         zrxToken.transferFrom(owner, user, 100);
         assertEq(zrxToken.allowance(owner, user), type(uint256).max);
@@ -106,7 +102,6 @@ contract ZRXTokenTest is Test {
     function testShouldTransferCorrectlyWhenSufficientAllowance() public {
         vm.prank(owner);
         zrxToken.approve(user, 1000 * 1e18);
-        vm.stopPrank();
 
         vm.prank(user);
         zrxToken.transferFrom(owner, user, 100 * 1e18);

--- a/contracts/governance/test/unit/ZeroExGovernorBaseTest.t.sol
+++ b/contracts/governance/test/unit/ZeroExGovernorBaseTest.t.sol
@@ -90,7 +90,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);
@@ -155,7 +154,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);
@@ -266,7 +264,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);
@@ -330,7 +327,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);
@@ -366,7 +362,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);
@@ -402,7 +397,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);
@@ -438,7 +432,6 @@ abstract contract ZeroExGovernorBaseTest is BaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);

--- a/contracts/governance/test/unit/ZeroExProtocolGovernor.t.sol
+++ b/contracts/governance/test/unit/ZeroExProtocolGovernor.t.sol
@@ -70,13 +70,12 @@ contract ZeroExProtocolGovernorTest is ZeroExGovernorBaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
+
         vm.prank(account3);
         governor.castVote(proposalId, 0); // Vote "against"
-        vm.stopPrank();
+
         vm.prank(account4);
         governor.castVote(proposalId, 2); // Vote "abstain"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);

--- a/contracts/governance/test/unit/ZeroExTreasuryGovernor.t.sol
+++ b/contracts/governance/test/unit/ZeroExTreasuryGovernor.t.sol
@@ -66,13 +66,12 @@ contract ZeroExTreasuryGovernorTest is ZeroExGovernorBaseTest {
         // Vote
         vm.prank(account2);
         governor.castVote(proposalId, 1); // Vote "for"
-        vm.stopPrank();
+
         vm.prank(account3);
         governor.castVote(proposalId, 0); // Vote "against"
-        vm.stopPrank();
+
         vm.prank(account4);
         governor.castVote(proposalId, 2); // Vote "abstain"
-        vm.stopPrank();
 
         // Fast forward to vote end
         vm.roll(governor.proposalDeadline(proposalId) + 1);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Closes LIT-1020. 
tl;dr: Foundry CI tests are failing due to the new version of forge reverting if we call `vm.stopPrank` without calling `vm.startPrank`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
