### PR TITLE
Fix usage of expectEmit in MetaTransactionsFeatureV2 tests

### DIFF
--- a/contracts/zero-ex/tests/MetaTransactionV2Test.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionV2Test.t.sol
@@ -274,10 +274,8 @@ contract MetaTransactionTest is LocalTest {
             address(this)
         );
 
-        IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(
-            mtxData,
-            sig
-        );
+        IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(mtxData, sig);
+
         assertEq(zrx.balanceOf(USER_ADDRESS), 1e18);
         assertEq(dai.balanceOf(USER_ADDRESS), 0);
         assertEq(weth.balanceOf(address(this)), 1);
@@ -297,10 +295,7 @@ contract MetaTransactionTest is LocalTest {
             address(this)
         );
 
-        IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(
-            mtxData,
-            sig
-        );
+        IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(mtxData, sig);
 
         assertEq(zrx.balanceOf(signerAddress), 0);
         assertEq(zrx.balanceOf(USER_ADDRESS), 1e18);
@@ -323,10 +318,7 @@ contract MetaTransactionTest is LocalTest {
             address(this)
         );
 
-        IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(
-            mtxData,
-            sig
-        );
+        IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(mtxData, sig);
 
         assertEq(zrx.balanceOf(signerAddress), 0);
         assertEq(zrx.balanceOf(USER_ADDRESS), 1e18);

--- a/contracts/zero-ex/tests/MetaTransactionV2Test.t.sol
+++ b/contracts/zero-ex/tests/MetaTransactionV2Test.t.sol
@@ -263,6 +263,7 @@ contract MetaTransactionTest is LocalTest {
     function test_transformERC20() external {
         bytes memory transformCallData = _transformERC20Call(zrx, dai, USER_ADDRESS);
         IMetaTransactionsFeatureV2.MetaTransactionDataV2 memory mtxData = _getMetaTransaction(transformCallData);
+        LibSignature.Signature memory sig = _mtxSignature(mtxData);
 
         assertEq(dai.balanceOf(USER_ADDRESS), 1e18);
         vm.expectEmit(true, false, false, true);
@@ -275,7 +276,7 @@ contract MetaTransactionTest is LocalTest {
 
         IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(
             mtxData,
-            _mtxSignature(mtxData)
+            sig
         );
         assertEq(zrx.balanceOf(USER_ADDRESS), 1e18);
         assertEq(dai.balanceOf(USER_ADDRESS), 0);
@@ -285,6 +286,7 @@ contract MetaTransactionTest is LocalTest {
     function test_rfqOrder() external {
         bytes memory callData = _makeTestRfqOrder(zrx, dai, signerAddress, USER_ADDRESS, signerKey);
         IMetaTransactionsFeatureV2.MetaTransactionDataV2 memory mtxData = _getMetaTransaction(callData);
+        LibSignature.Signature memory sig = _mtxSignature(mtxData);
 
         assertEq(dai.balanceOf(USER_ADDRESS), 1e18);
         vm.expectEmit(true, false, false, true);
@@ -297,7 +299,7 @@ contract MetaTransactionTest is LocalTest {
 
         IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(
             mtxData,
-            _mtxSignature(mtxData)
+            sig
         );
 
         assertEq(zrx.balanceOf(signerAddress), 0);
@@ -310,6 +312,7 @@ contract MetaTransactionTest is LocalTest {
     function test_fillLimitOrder() external {
         bytes memory callData = _makeTestLimitOrder(zrx, dai, signerAddress, USER_ADDRESS, signerKey);
         IMetaTransactionsFeatureV2.MetaTransactionDataV2 memory mtxData = _getMetaTransaction(callData);
+        LibSignature.Signature memory sig = _mtxSignature(mtxData);
 
         assertEq(dai.balanceOf(USER_ADDRESS), 1e18);
         vm.expectEmit(true, false, false, true);
@@ -322,7 +325,7 @@ contract MetaTransactionTest is LocalTest {
 
         IMetaTransactionsFeatureV2(address(zeroExDeployed.zeroEx)).executeMetaTransactionV2(
             mtxData,
-            _mtxSignature(mtxData)
+            sig
         );
 
         assertEq(zrx.balanceOf(signerAddress), 0);


### PR DESCRIPTION
## Description

We are using forge's `vm.expectEmit` incorrectly in a few tests causing the tests to fail. This change corrects our usage in `MetaTransactionV2Test.t.sol`. The tests were previously passing, perhaps because of some bug in forge that must have been patched recently.

## Testing instructions

`forge test --match-contract MetaTransactionTest`

## Types of changes

* Bug fix (non-breaking change which fixes an issue)
