### PR TITLE
[docs] fix broken links

### DIFF
--- a/docs/architecture/features.rst
+++ b/docs/architecture/features.rst
@@ -2,7 +2,7 @@
 Features
 ###############################
 
-Features implement the core feature set of the 0x Protocol. They are trusted with user allowances and permissioned by the `0x Governor <./governor.html>`_. Features are run in the context of the `Proxy <../proxy.html>`_, via a ``delegatecall``.
+Features implement the core feature set of the 0x Protocol. They are trusted with user allowances and permissioned by the `0x Governor <./governor.html>`_. Features are run in the context of the `Proxy <./proxy.html>`_, via a ``delegatecall``.
 
 Below is a catalog of Features.
 

--- a/docs/architecture/proxy.rst
+++ b/docs/architecture/proxy.rst
@@ -201,7 +201,7 @@ Every time we develop a new feature, an entry is appended to the ``LibStorage.St
     }
 
 
-Given Solidity’s `storage layout rules <https://solidity.readthedocs.io/en/v0.6.6/miscellaneous.html)>`_, subsequent storage buckets should always be 2^128 slots apart, which means buckets can have 2^128 flattened inline fields before overlapping. While it’s not impossible for buckets to overlap with this pattern, it should be extremely unlikely if we follow it closely. Maps and arrays are not stored sequentially but should also be affected by their base slot value to make collisions unlikely.
+Given Solidity’s `storage layout rules <https://solidity.readthedocs.io/en/v0.6.6/miscellaneous.html>`_, subsequent storage buckets should always be 2^128 slots apart, which means buckets can have 2^128 flattened inline fields before overlapping. While it’s not impossible for buckets to overlap with this pattern, it should be extremely unlikely if we follow it closely. Maps and arrays are not stored sequentially but should also be affected by their base slot value to make collisions unlikely.
 
 **Inherited Storage**
 


### PR DESCRIPTION
## Description

I was reading through the 0x docs and noticed a broken link, so this PR fixes the broken link to the proxy page from the [feature](https://docs.0xprotocol.org/en/latest/architecture/features.html) page.

I have not included any tests or changelog updates for this PR. Please let me know if/where I should add any of these.

## Testing instructions

To my knowledge, not much testing can be done until the updated version of these docs are deployed. However since `governor.rst` and `proxy.rst` are in the same directory, you can see that the relative path for `proxy` is now identical to the relative path for `governor` in this screenshot:

![0xdocfix](https://github.com/0xProject/protocol/assets/80664544/022f3318-2851-4939-b8fe-cd5bf8259abf)

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
