### PR TITLE
Add UniswapV3 to Avalanche and BSC bridge adapters

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -10,6 +10,9 @@
             },
             {
                 "note": "Add Base Mainnet and Goerli BridgeAdapters"
+            },
+            {
+                "note": "Add Uniswap V3 support on Avalanche and BSC"
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/transformers/bridges/AvalancheBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/AvalancheBridgeAdapter.sol
@@ -28,6 +28,7 @@ import "./mixins/MixinNerve.sol";
 import "./mixins/MixinPlatypus.sol";
 import "./mixins/MixinTraderJoeV2.sol";
 import "./mixins/MixinUniswapV2.sol";
+import "./mixins/MixinUniswapV3.sol";
 import "./mixins/MixinWOOFi.sol";
 import "./mixins/MixinZeroExBridge.sol";
 
@@ -44,6 +45,7 @@ contract AvalancheBridgeAdapter is
     MixinPlatypus,
     MixinTraderJoeV2,
     MixinUniswapV2,
+    MixinUniswapV3,
     MixinWOOFi,
     MixinZeroExBridge
 {
@@ -72,6 +74,11 @@ contract AvalancheBridgeAdapter is
                 return (0, true);
             }
             boughtAmount = _tradeUniswapV2(buyToken, sellAmount, order.bridgeData);
+        } else if (protocolId == BridgeProtocols.UNISWAPV3) {
+            if (dryRun) {
+                return (0, true);
+            }
+            boughtAmount = _tradeUniswapV3(sellToken, sellAmount, order.bridgeData);
         } else if (protocolId == BridgeProtocols.NERVE) {
             if (dryRun) {
                 return (0, true);

--- a/contracts/zero-ex/contracts/src/transformers/bridges/BSCBridgeAdapter.sol
+++ b/contracts/zero-ex/contracts/src/transformers/bridges/BSCBridgeAdapter.sol
@@ -25,6 +25,7 @@ import "./mixins/MixinKyberElastic.sol";
 import "./mixins/MixinMooniswap.sol";
 import "./mixins/MixinNerve.sol";
 import "./mixins/MixinUniswapV2.sol";
+import "./mixins/MixinUniswapV3.sol";
 import "./mixins/MixinWOOFi.sol";
 import "./mixins/MixinZeroExBridge.sol";
 
@@ -38,6 +39,7 @@ contract BSCBridgeAdapter is
     MixinMooniswap,
     MixinNerve,
     MixinUniswapV2,
+    MixinUniswapV3,
     MixinWOOFi,
     MixinZeroExBridge
 {
@@ -61,6 +63,11 @@ contract BSCBridgeAdapter is
                 return (0, true);
             }
             boughtAmount = _tradeUniswapV2(buyToken, sellAmount, order.bridgeData);
+        } else if (protocolId == BridgeProtocols.UNISWAPV3) {
+            if (dryRun) {
+                return (0, true);
+            }
+            boughtAmount = _tradeUniswapV3(sellToken, sellAmount, order.bridgeData);
         } else if (protocolId == BridgeProtocols.MOONISWAP) {
             if (dryRun) {
                 return (0, true);

--- a/packages/contract-addresses/CHANGELOG.json
+++ b/packages/contract-addresses/CHANGELOG.json
@@ -4,6 +4,9 @@
 		"changes": [
 			{
 				"note": "Add Base mainnet addresses"
+			},
+			{
+				"note": "Add UniswapV3 support in Avalanche and BSC FillQuoteTransformers"
 			}
 		]
 	},

--- a/packages/contract-addresses/addresses.json
+++ b/packages/contract-addresses/addresses.json
@@ -64,7 +64,7 @@
             "wethTransformer": "0xac3d95668c092e895cd83a9cbafe9c7d9906471f",
             "payTakerTransformer": "0x7e788f3a3e39cdd1944ba111fafc5fb7e59b5e90",
             "affiliateFeeTransformer": "0x043300d113de0c64684ab89c56a45cd94c7ef54c",
-            "fillQuoteTransformer": "0x43d10801db01c28093265ef9b77d532e553fa578",
+            "fillQuoteTransformer": "0xa9c57c539690d4e1439411f648ead5b121b34a23",
             "positiveSlippageFeeTransformer": "0x6ff35e8cbaf56d8a8f6bf9963b902a4576243030"
         }
     },
@@ -156,7 +156,7 @@
             "wethTransformer": "0x9b8b52391071d71cd4ad1e61d7f273268fa34c6c",
             "payTakerTransformer": "0xb9a4c32547bc3cdc2ee2fb13cc1a0717dac9888f",
             "affiliateFeeTransformer": "0x105679f99d668001370b4621ad8648ac570c860f",
-            "fillQuoteTransformer": "0x886e4f97d7e06ab66dba574a7a861046dcf7ae4f",
+            "fillQuoteTransformer": "0x463fe1a80acb62ce1e4f0a4f7b83df674c2cce2c",
             "positiveSlippageFeeTransformer": "0xadbfdc58a24b6dbc16f21541800f43dd6e282250"
         }
     },


### PR DESCRIPTION
## Description
* Fixes LIT-1176
* Add Uniswap V3 to Avalanche and BSC bridge adapters
* Add router v2 support in `MixinUniswapV3` (backward compatible)
  * This change is needed as newer Uniswap V3 deployments do not have router v1 (e.g. BSC, Avalanche).
* Update Avalanche/BSC FillQuoteTransformer addresses 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
