### PR TITLE
Update reference.mdx

### DIFF
--- a/packages/contract-wrappers/docs/reference.mdx
+++ b/packages/contract-wrappers/docs/reference.mdx
@@ -5003,7 +5003,7 @@ Function signature for encoding MultiAsset assetData.
 Name | Type | Description |
 ------ | ------ | ------ |
 `values` | `BigNumber`[] | Array of amounts that correspond to each asset to be     transferred.        Note that each value will be multiplied by the     amount being filled in the order before transferring. |
-`nestedAssetData` | string[] | Array of assetData fields that will be be dispatched     to their correspnding AssetProxy contract.  |
+`nestedAssetData` | string[] | Array of assetData fields that will be be dispatched     to their corresponding AssetProxy contract.  |
 
 **Returns:** *`ContractTxFunctionObj<void>`*
 


### PR DESCRIPTION
# Fix Typo in `reference.mdx`

## Summary  
This pull request corrects a minor typo in `packages/contract-wrappers/docs/reference.mdx`.

## Changes  
- Fixed "correspnding" → "corresponding"  

## Context  
This update improves documentation accuracy and readability.

## Checklist  
- [x] Spelling and grammar checked  
- [x] No breaking changes  
- [x] Ready for review  

## Related Issues  
N/A  

---

Let me know if you need any modifications!
